### PR TITLE
chore: adjust semantic PR validation rule

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,62 +1,8 @@
-# Always validate the PR title AND all the commits
-titleAndCommits: true
-# Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
-# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
-allowMergeCommits: true
-# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
-# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
-allowRevertCommits: true
-# By default types specified in commitizen/conventional-commit-types is used.
-# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
-# {
-  #  "types": {
-  #    "feat": {
-  #      "description": "A new feature",
-  #      "title": "Features"
-  #    },
-  #    "fix": {
-  #      "description": "A bug fix",
-  #      "title": "Bug Fixes"
-  #    },
-  #    "docs": {
-  #      "description": "Documentation only changes",
-  #      "title": "Documentation"
-  #    },
-  #    "style": {
-  #      "description": "Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)",
-  #      "title": "Styles"
-  #    },
-  #    "refactor": {
-  #      "description": "A code change that neither fixes a bug nor adds a feature",
-  #      "title": "Code Refactoring"
-  #    },
-  #    "perf": {
-  #      "description": "A code change that improves performance",
-  #      "title": "Performance Improvements"
-  #    },
-  #    "test": {
-  #      "description": "Adding missing tests or correcting existing tests",
-  #      "title": "Tests"
-  #    },
-  #    "build": {
-  #      "description": "Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)",
-  #      "title": "Builds"
-  #    },
-  #    "ci": {
-  #      "description": "Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)",
-  #      "title": "Continuous Integrations"
-  #    },
-  #    "chore": {
-  #      "description": "Other changes that don't modify src or test files",
-  #      "title": "Chores"
-  #    },
-  #    "revert": {
-  #      "description": "Reverts a previous commit",
-  #      "title": "Reverts"
-  #    }
-#  }
-#}
-# You can override the valid types
+# As we use Squash `Squash and merge` for the PR merging rule, the PR title validation only needed.
+titleOnly: true
+
+# The type rule is based on the Angular convention
+# > https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type
 types:
   - feat
   - fix


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

As we use `Squash and merge` for the PR merging rule, the PR title validation only needed.
So this PR adjusts the `Semantic Pull Request` rules.

> https://github.com/zeke/semantic-pull-requests#configuration

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I followed the [contributing guidelines](https://github.com/line/link/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
