### PR TITLE
docs: add copyright to license and notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 LINE TECH PLUS Pte., Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,7 @@
 Copyright 2019 Jehan Tremback
 Copyright 2019-2020 Confio UO
 Copyright 2019-2020 Simon Warta
+Copyright 2021 LINE TECH PLUS Pte., Ltd.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds the copyright to the license and notice files.

- adds to ./`LICENSE`, ./`NOTICE`
- does not add to the files of contract examples because we do not modify them. 
  - e.g. https://github.com/line/cosmwasm/blob/main/contracts/burner/NOTICE