### PR TITLE
fix: export DivideByZeroError to pub

### DIFF
--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -30,7 +30,7 @@ pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::deps::{Deps, DepsMut, OwnedDeps};
 pub use crate::errors::{
     OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult, SystemError,
-    VerificationError,
+    VerificationError, DivideByZeroError,
 };
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -29,8 +29,8 @@ pub use crate::binary::Binary;
 pub use crate::coins::{coin, coins, has_coins, Coin};
 pub use crate::deps::{Deps, DepsMut, OwnedDeps};
 pub use crate::errors::{
-    OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult, SystemError,
-    VerificationError, DivideByZeroError,
+    DivideByZeroError, OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult,
+    SystemError, VerificationError,
 };
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{


### PR DESCRIPTION
# Description

In `StdError` like `OverflowError`, if the struct is positioned as a field, the struct type must also be exposed as `pub`.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
