### PR TITLE
feat: add import&export macro and serialized data copy pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "cosmwasm-std",
+ "quote",
  "syn",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "cosmwasm-std",
+ "proc-macro-error",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ version = "0.14.0-0.4.0"
 dependencies = [
  "cosmwasm-std",
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -142,6 +142,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/burner/Cargo.lock
+++ b/contracts/burner/Cargo.lock
@@ -143,6 +143,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -144,6 +144,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/crypto-verify/Cargo.lock
+++ b/contracts/crypto-verify/Cargo.lock
@@ -145,6 +145,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/dynamic-callee-contract/.cargo/config
+++ b/contracts/dynamic-callee-contract/.cargo/config
@@ -2,3 +2,4 @@
 wasm = "build --release --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --example schema"
+integration-test = "test --test integration"

--- a/contracts/dynamic-callee-contract/Cargo.lock
+++ b/contracts/dynamic-callee-contract/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/dynamic-callee-contract/Cargo.lock
+++ b/contracts/dynamic-callee-contract/Cargo.lock
@@ -3,10 +3,61 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.1",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object 0.27.1",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -35,10 +86,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clru"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"
@@ -98,12 +167,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-vm"
+version = "0.14.0-0.4.0"
+dependencies = [
+ "clru",
+ "cosmwasm-crypto",
+ "cosmwasm-std",
+ "hex",
+ "parity-wasm",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "wasmer",
+ "wasmer-middlewares",
+ "wasmer-types",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9221545c0507dc08a62b2d8b5ffe8e17ac580b0a74d1813b496b8d70b070fbd0"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9936ea608b6cd176f107037f6adbb4deac933466fc7231154f96598b2d3ab1"
+dependencies = [
+ "byteorder",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.22.0",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef2b2768568306540f4c8db3acce9105534d34c4a1e440529c1e702d7f8c8d7"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6759012d6d19c4caec95793f052613e9d4113e925e7f14154defbac0f1d4c938"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b608bb7656c554d0a4cf8f50c7a10b857e80306f6ff829ad6d468a7e2323c8d8"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -127,6 +333,41 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -160,9 +401,37 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cosmwasm-vm",
  "schemars",
  "serde",
  "thiserror",
+ "wasmer-types",
+]
+
+[[package]]
+name = "dynasm"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b1801e630bd336d0bbbdbf814de6cc749c9a400c7e3d995e6adfd455d0c83c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d428afc93ad288f6dffc1fa5f4a78201ad2eec33c5a522e51c181009eb09061"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "memmap2 0.5.3",
 ]
 
 [[package]]
@@ -191,6 +460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +484,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +529,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -241,10 +558,27 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "group"
@@ -255,6 +589,21 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -274,6 +623,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,11 +660,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "sha2",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -298,10 +685,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pkcs8"
@@ -321,6 +826,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
+ "syn",
  "version_check",
 ]
 
@@ -369,6 +875,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +1002,15 @@ name = "serde-json-wasm"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "042ac496d97e5885149d34139bad1d617192770d7eb8f1866da2317ff4501853"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
  "serde",
 ]
@@ -456,7 +1055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -469,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -486,6 +1085,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +1117,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -523,10 +1160,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -555,6 +1230,270 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasmer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70cfae554988d904d64ca17ab0e7cd652ee5c8a0807094819c1ea93eb9d6866"
+dependencies = [
+ "cfg-if 0.1.10",
+ "indexmap",
+ "more-asserts",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-compiler-singlepass",
+ "wasmer-derive",
+ "wasmer-engine",
+ "wasmer-engine-jit",
+ "wasmer-engine-native",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7732a9cab472bd921d5a0c422f45b3d03f62fa2c40a89e0770cef6d47e383e"
+dependencies = [
+ "enumset",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb9395f094e1d81534f4c5e330ed4cdb424e8df870d29ad585620284f5fddb"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "gimli 0.22.0",
+ "more-asserts",
+ "rayon",
+ "serde",
+ "smallvec",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-compiler-singlepass"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426ae6ef0f606ca815510f3e2ef6f520e217514bfb7a664defe180b9a9e75d07"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "lazy_static",
+ "more-asserts",
+ "rayon",
+ "serde",
+ "smallvec",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b86dcd2c3efdb8390728a2b56f762db07789aaa5aa872a9dc776ba3a7912ed"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe4667d6bd888f26ae8062a63a9379fa697415b4b4e380f33832e8418fd71b5"
+dependencies = [
+ "backtrace",
+ "bincode",
+ "lazy_static",
+ "memmap2 0.2.3",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-jit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26770be802888011b4a3072f2a282fc2faa68aa48c71b3db6252a3937a85f3da"
+dependencies = [
+ "bincode",
+ "cfg-if 0.1.10",
+ "region",
+ "serde",
+ "serde_bytes",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-types",
+ "wasmer-vm",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-engine-native"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb4083a6c69f2cd4b000b82a80717f37c6cc2e536aee3a8ffe9af3edc276a8b"
+dependencies = [
+ "bincode",
+ "cfg-if 0.1.10",
+ "leb128",
+ "libloading",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
+]
+
+[[package]]
+name = "wasmer-middlewares"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547baee2c0733cf436db7d137a8d1f86737a6321fc0fe6cd74caecf6f759c3c4"
+dependencies = [
+ "wasmer",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf8e0c12b82ff81ebecd30d7e118be5fec871d6de885a90eeb105df0a769a7b"
+dependencies = [
+ "object 0.22.0",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f4ac28c2951cd792c18332f03da523ed06b170f5cf6bb5b1bdd7e36c2a8218"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7635ba0b6d2fd325f588d69a950ad9fa04dddbf6ad08b6b2a183146319bf6ae"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 0.1.10",
+ "indexmap",
+ "libc",
+ "memoffset",
+ "more-asserts",
+ "region",
+ "serde",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
+
+[[package]]
+name = "wast"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bbbd53432b267421186feee3e52436531fa69a7cfee9403f5204352df3dd05"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
+dependencies = [
+ "wast",
+]
+
+[[package]]
+name = "which"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"

--- a/contracts/dynamic-callee-contract/Cargo.lock
+++ b/contracts/dynamic-callee-contract/Cargo.lock
@@ -62,6 +62,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 
@@ -308,6 +310,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
 dependencies = [
  "der",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/contracts/dynamic-callee-contract/Cargo.toml
+++ b/contracts/dynamic-callee-contract/Cargo.toml
@@ -33,3 +33,5 @@ thiserror = { version = "1.0.24" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
+wasmer-types = { version = "1.0.2"}

--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, callable_point,
+    callable_point, entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    StdResult,
 };
 use serde::{Deserialize, Serialize};
 
@@ -22,7 +23,6 @@ pub fn instantiate(
 fn pong(x: u64) -> u64 {
     return x + 1;
 }
-
 
 #[derive(Serialize, Deserialize)]
 pub struct ExampleStruct {

--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{
-    entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult,
+    entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, callable_point,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -9,31 +10,45 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 // make use of the custom errors
 #[entry_point]
 pub fn instantiate(
-    _deps: DepsMut,
+    deps: DepsMut,
     _env: Env,
-    _info: MessageInfo,
-    _msg: InstantiateMsg,
+    info: MessageInfo,
+    msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     Ok(Response::default())
 }
 
-#[no_mangle]
-extern "C" fn pong(x: u64) -> u64 {
+#[callable_point]
+fn pong(x: u64) -> u64 {
     return x + 1;
+}
+
+
+#[derive(Serialize, Deserialize)]
+pub struct ExampleStruct {
+    pub str_field: String,
+    pub u64_field: u64,
+}
+#[callable_point]
+fn pong_with_struct(example: ExampleStruct) -> ExampleStruct {
+    ExampleStruct {
+        str_field: example.str_field + " world",
+        u64_field: example.u64_field + 1,
+    }
 }
 
 // And declare a custom Error variant for the ones where you will want to make use of it
 #[entry_point]
 pub fn execute(
-    _deps: DepsMut,
+    deps: DepsMut,
     _env: Env,
-    _info: MessageInfo,
+    info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {}
 }
 
 #[entry_point]
-pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {}
 }

--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    callable_point, entry_point, to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    callable_point, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response,
     StdResult,
 };
 use serde::{Deserialize, Serialize};
@@ -11,10 +11,10 @@ use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 // make use of the custom errors
 #[entry_point]
 pub fn instantiate(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
-    msg: InstantiateMsg,
+    _info: MessageInfo,
+    _msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     Ok(Response::default())
 }
@@ -40,15 +40,15 @@ fn pong_with_struct(example: ExampleStruct) -> ExampleStruct {
 // And declare a custom Error variant for the ones where you will want to make use of it
 #[entry_point]
 pub fn execute(
-    deps: DepsMut,
+    _deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {}
 }
 
 #[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {}
 }

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -1,39 +1,47 @@
-use std::collections::HashMap;
-use wasmer_types::{Type, FunctionType};
-use cosmwasm_std::{to_vec, from_slice};
-use cosmwasm_vm::testing::{Contract, mock_backend, MockInstanceOptions, write_data_to_mock_env, read_data_from_mock_env};
+use cosmwasm_std::{from_slice, to_vec};
+use cosmwasm_vm::testing::{
+    mock_backend, read_data_from_mock_env, write_data_to_mock_env, Contract, MockInstanceOptions,
+};
 use dynamic_callee_contract::contract::ExampleStruct;
+use std::collections::HashMap;
+use wasmer_types::{FunctionType, Type};
 
 static CONTRACT_CALLEE: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/dynamic_callee_contract.wasm");
 
-
 fn required_exports() -> Vec<(String, FunctionType)> {
-    vec![(String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
-    (String::from("stub_pong_with_struct"), ([Type::I32], [Type::I32]).into()),]
+    vec![
+        (String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
+        (
+            String::from("stub_pong_with_struct"),
+            ([Type::I32], [Type::I32]).into(),
+        ),
+    ]
 }
-
 
 #[test]
 fn callable_point_export_works() {
     let options = MockInstanceOptions::default();
     let backend = mock_backend(&[]);
     let contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
-    
-    let export_function_map: HashMap<_, _> = contract.module.exports().functions().map(|export|{
-        (export.name().to_string(), export.ty().clone())
-    }).collect::<Vec<(String, FunctionType)>>()
-    .into_iter()
-    .collect();
-    
+
+    let export_function_map: HashMap<_, _> = contract
+        .module
+        .exports()
+        .functions()
+        .map(|export| (export.name().to_string(), export.ty().clone()))
+        .collect::<Vec<(String, FunctionType)>>()
+        .into_iter()
+        .collect();
+
     let required_exports = required_exports();
     for required_export in required_exports {
         match export_function_map.get(&required_export.0) {
             Some(exported_function) => {
                 assert_eq!(*exported_function, required_export.1);
-            },
+            }
             None => assert!(false),
-        }  
+        }
     }
 }
 
@@ -43,16 +51,22 @@ fn callable_point_pong_works() {
     let backend = mock_backend(&[]);
     let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
     let instance = contract.generate_instance().unwrap();
-    
 
     let serialized_param = to_vec(&10u64).unwrap();
     let param_region_ptr = write_data_to_mock_env(&instance.env, &serialized_param).unwrap();
 
     let required_exports = required_exports();
-    let call_result = instance.call_function_strict(&required_exports[0].1, "stub_pong", &[param_region_ptr.into()]).unwrap();
+    let call_result = instance
+        .call_function_strict(
+            &required_exports[0].1,
+            "stub_pong",
+            &[param_region_ptr.into()],
+        )
+        .unwrap();
     assert_eq!(call_result.len(), 1);
-    
-    let serialized_return = read_data_from_mock_env(&instance.env, &call_result[0], usize::MAX).unwrap();
+
+    let serialized_return =
+        read_data_from_mock_env(&instance.env, &call_result[0], usize::MAX).unwrap();
     let result: u64 = from_slice(&serialized_return).unwrap();
     assert_eq!(result, 11u64);
 }
@@ -63,18 +77,26 @@ fn callable_point_pong_with_struct_works() {
     let backend = mock_backend(&[]);
     let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
     let instance = contract.generate_instance().unwrap();
-    
-    let serialized_param = to_vec(&ExampleStruct{
+
+    let serialized_param = to_vec(&ExampleStruct {
         str_field: String::from("hello"),
         u64_field: 100u64,
-    }).unwrap();
+    })
+    .unwrap();
     let param_region_ptr = write_data_to_mock_env(&instance.env, &serialized_param).unwrap();
 
     let required_exports = required_exports();
-    let call_result = instance.call_function_strict(&required_exports[1].1, "stub_pong_with_struct", &[param_region_ptr.into()]).unwrap();
+    let call_result = instance
+        .call_function_strict(
+            &required_exports[1].1,
+            "stub_pong_with_struct",
+            &[param_region_ptr.into()],
+        )
+        .unwrap();
     assert_eq!(call_result.len(), 1);
 
-    let serialized_return = read_data_from_mock_env(&instance.env, &call_result[0], u32::MAX as usize).unwrap();
+    let serialized_return =
+        read_data_from_mock_env(&instance.env, &call_result[0], u32::MAX as usize).unwrap();
     let result: ExampleStruct = from_slice(&serialized_return).unwrap();
     assert_eq!(result.str_field, String::from("hello world"));
     assert_eq!(result.u64_field, 101);

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -66,7 +66,7 @@ fn callable_point_pong_works() {
     assert_eq!(call_result.len(), 1);
 
     let serialized_return =
-        read_data_from_mock_env(&instance.env, &call_result[0], usize::MAX).unwrap();
+        read_data_from_mock_env(&instance.env, &call_result[0], u32::MAX as usize).unwrap();
     let result: u64 = from_slice(&serialized_return).unwrap();
     assert_eq!(result, 11u64);
 }

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use wasmer_types::{Type, FunctionType};
+use cosmwasm_std::{to_vec, from_slice};
+use cosmwasm_vm::testing::{Contract, mock_backend, MockInstanceOptions, write_data_to_mock_env, read_data_from_mock_env};
+use dynamic_callee_contract::contract::ExampleStruct;
+
+static CONTRACT_CALLEE: &[u8] =
+    include_bytes!("../target/wasm32-unknown-unknown/release/dynamic_callee_contract.wasm");
+
+
+fn required_exports() -> Vec<(String, FunctionType)> {
+    vec![(String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
+    (String::from("stub_pong_with_struct"), ([Type::I32], [Type::I32]).into()),]
+}
+
+
+#[test]
+fn callable_point_export_works() {
+    let options = MockInstanceOptions::default();
+    let backend = mock_backend(&[]);
+    let contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
+    
+    let export_function_map: HashMap<_, _> = contract.module.exports().functions().map(|export|{
+        (export.name().to_string(), export.ty().clone())
+    }).collect::<Vec<(String, FunctionType)>>()
+    .into_iter()
+    .collect();
+    
+    let required_exports = required_exports();
+    for required_export in required_exports {
+        match export_function_map.get(&required_export.0) {
+            Some(exported_function) => {
+                assert_eq!(*exported_function, required_export.1);
+            },
+            None => assert!(false),
+        }  
+    }
+}
+
+#[test]
+fn callable_point_pong_works() {
+    let options = MockInstanceOptions::default();
+    let backend = mock_backend(&[]);
+    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
+    let instance = contract.generate_instance().unwrap();
+    
+
+    let serialized_param = to_vec(&10u64).unwrap();
+    let param_region_ptr = write_data_to_mock_env(&instance.env, &serialized_param).unwrap();
+
+    let required_exports = required_exports();
+    let call_result = instance.call_function_strict(&required_exports[0].1, "stub_pong", &[param_region_ptr.into()]).unwrap();
+    assert_eq!(call_result.len(), 1);
+    
+    let serialized_return = read_data_from_mock_env(&instance.env, &call_result[0], usize::MAX).unwrap();
+    let result: u64 = from_slice(&serialized_return).unwrap();
+    assert_eq!(result, 11u64);
+}
+
+#[test]
+fn callable_point_pong_with_struct_works() {
+    let options = MockInstanceOptions::default();
+    let backend = mock_backend(&[]);
+    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
+    let instance = contract.generate_instance().unwrap();
+    
+    let serialized_param = to_vec(&ExampleStruct{
+        str_field: String::from("hello"),
+        u64_field: 100u64,
+    }).unwrap();
+    let param_region_ptr = write_data_to_mock_env(&instance.env, &serialized_param).unwrap();
+
+    let required_exports = required_exports();
+    let call_result = instance.call_function_strict(&required_exports[1].1, "stub_pong_with_struct", &[param_region_ptr.into()]).unwrap();
+    assert_eq!(call_result.len(), 1);
+
+    let serialized_return = read_data_from_mock_env(&instance.env, &call_result[0], u32::MAX as usize).unwrap();
+    let result: ExampleStruct = from_slice(&serialized_return).unwrap();
+    assert_eq!(result.str_field, String::from("hello world"));
+    assert_eq!(result.u64_field, 101);
+}

--- a/contracts/dynamic-caller-contract/.cargo/config
+++ b/contracts/dynamic-caller-contract/.cargo/config
@@ -2,3 +2,4 @@
 wasm = "build --release --target wasm32-unknown-unknown"
 unit-test = "test --lib"
 schema = "run --example schema"
+integration-test = "test --test integration"

--- a/contracts/dynamic-caller-contract/Cargo.lock
+++ b/contracts/dynamic-caller-contract/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/dynamic-caller-contract/Cargo.lock
+++ b/contracts/dynamic-caller-contract/Cargo.lock
@@ -3,10 +3,61 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli 0.26.1",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e121dee8023ce33ab248d9ce1493df03c3b38a659b240096fcbd7048ff9c31f"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object 0.27.1",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -35,10 +86,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clru"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "591ff76ca0691bd91c1b0b5b987e5cf93b21ec810ad96665c5a569c60846dd93"
 
 [[package]]
 name = "const-oid"
@@ -98,12 +167,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-vm"
+version = "0.14.0-0.4.0"
+dependencies = [
+ "clru",
+ "cosmwasm-crypto",
+ "cosmwasm-std",
+ "hex",
+ "parity-wasm",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "wasmer",
+ "wasmer-middlewares",
+ "wasmer-types",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9221545c0507dc08a62b2d8b5ffe8e17ac580b0a74d1813b496b8d70b070fbd0"
+dependencies = [
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9936ea608b6cd176f107037f6adbb4deac933466fc7231154f96598b2d3ab1"
+dependencies = [
+ "byteorder",
+ "cranelift-bforest",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+ "gimli 0.22.0",
+ "log",
+ "regalloc",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ef2b2768568306540f4c8db3acce9105534d34c4a1e440529c1e702d7f8c8d7"
+dependencies = [
+ "cranelift-codegen-shared",
+ "cranelift-entity",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6759012d6d19c4caec95793f052613e9d4113e925e7f14154defbac0f1d4c938"
+
+[[package]]
+name = "cranelift-entity"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86badbce14e15f52a45b666b38abe47b204969dd7f8fb7488cb55dd46b361fa6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.68.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b608bb7656c554d0a4cf8f50c7a10b857e80306f6ff829ad6d468a7e2323c8d8"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -127,6 +333,41 @@ dependencies = [
  "rand_core",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a340f241d2ceed1deb47ae36c4144b2707ec7dd0b649f894cb39bb595986324"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -160,9 +401,37 @@ dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
+ "cosmwasm-vm",
  "schemars",
  "serde",
  "thiserror",
+ "wasmer-types",
+]
+
+[[package]]
+name = "dynasm"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b1801e630bd336d0bbbdbf814de6cc749c9a400c7e3d995e6adfd455d0c83c"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dynasmrt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d428afc93ad288f6dffc1fa5f4a78201ad2eec33c5a522e51c181009eb09061"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "memmap2 0.5.3",
 ]
 
 [[package]]
@@ -191,6 +460,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,6 +484,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumset"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +529,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -241,10 +558,27 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
+dependencies = [
+ "fallible-iterator",
+ "indexmap",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "group"
@@ -255,6 +589,21 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -274,6 +623,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,11 +660,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4476a0808212a9e81ce802eb1a0cfc60e73aea296553bacc0fac7e1268bc572a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ecdsa",
  "elliptic-curve",
  "sha2",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leb128"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
@@ -298,10 +685,128 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi",
+]
+
+[[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "mach"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memmap2"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
+name = "more-asserts"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+dependencies = [
+ "crc32fast",
+ "indexmap",
+]
+
+[[package]]
+name = "object"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "parity-wasm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pkcs8"
@@ -321,6 +826,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
+ "syn",
  "version_check",
 ]
 
@@ -369,6 +875,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regalloc"
+version = "0.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571f7f397d61c4755285cd37853fe8e03271c243424a907415909379659381c5"
+dependencies = [
+ "log",
+ "rustc-hash",
+ "smallvec",
+]
+
+[[package]]
+name = "region"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877e54ea2adcd70d80e9179344c97f93ef0dffd6b03e1f4529e6e83ab2fa9ae0"
+dependencies = [
+ "bitflags",
+ "libc",
+ "mach",
+ "winapi",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +983,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +1002,15 @@ name = "serde-json-wasm"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "042ac496d97e5885149d34139bad1d617192770d7eb8f1866da2317ff4501853"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16ae07dd2f88a366f15bd0632ba725227018c69a1c8550a927324f8eb8368bb9"
 dependencies = [
  "serde",
 ]
@@ -456,7 +1055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -469,7 +1068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
  "opaque-debug",
@@ -486,6 +1085,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "subtle"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +1117,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "422045212ea98508ae3d28025bc5aaa2bd4a9cdaecd442a08da2ee620ee9ea95"
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -523,10 +1160,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
@@ -555,6 +1230,270 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasmer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a70cfae554988d904d64ca17ab0e7cd652ee5c8a0807094819c1ea93eb9d6866"
+dependencies = [
+ "cfg-if 0.1.10",
+ "indexmap",
+ "more-asserts",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-compiler-cranelift",
+ "wasmer-compiler-singlepass",
+ "wasmer-derive",
+ "wasmer-engine",
+ "wasmer-engine-jit",
+ "wasmer-engine-native",
+ "wasmer-types",
+ "wasmer-vm",
+ "wat",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-compiler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b7732a9cab472bd921d5a0c422f45b3d03f62fa2c40a89e0770cef6d47e383e"
+dependencies = [
+ "enumset",
+ "serde",
+ "serde_bytes",
+ "smallvec",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-types",
+ "wasmer-vm",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmer-compiler-cranelift"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48cb9395f094e1d81534f4c5e330ed4cdb424e8df870d29ad585620284f5fddb"
+dependencies = [
+ "cranelift-codegen",
+ "cranelift-frontend",
+ "gimli 0.22.0",
+ "more-asserts",
+ "rayon",
+ "serde",
+ "smallvec",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-compiler-singlepass"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "426ae6ef0f606ca815510f3e2ef6f520e217514bfb7a664defe180b9a9e75d07"
+dependencies = [
+ "byteorder",
+ "dynasm",
+ "dynasmrt",
+ "lazy_static",
+ "more-asserts",
+ "rayon",
+ "serde",
+ "smallvec",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-derive"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b86dcd2c3efdb8390728a2b56f762db07789aaa5aa872a9dc776ba3a7912ed"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "wasmer-engine"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efe4667d6bd888f26ae8062a63a9379fa697415b4b4e380f33832e8418fd71b5"
+dependencies = [
+ "backtrace",
+ "bincode",
+ "lazy_static",
+ "memmap2 0.2.3",
+ "more-asserts",
+ "rustc-demangle",
+ "serde",
+ "serde_bytes",
+ "target-lexicon",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-engine-jit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26770be802888011b4a3072f2a282fc2faa68aa48c71b3db6252a3937a85f3da"
+dependencies = [
+ "bincode",
+ "cfg-if 0.1.10",
+ "region",
+ "serde",
+ "serde_bytes",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-types",
+ "wasmer-vm",
+ "winapi",
+]
+
+[[package]]
+name = "wasmer-engine-native"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb4083a6c69f2cd4b000b82a80717f37c6cc2e536aee3a8ffe9af3edc276a8b"
+dependencies = [
+ "bincode",
+ "cfg-if 0.1.10",
+ "leb128",
+ "libloading",
+ "serde",
+ "tempfile",
+ "tracing",
+ "wasmer-compiler",
+ "wasmer-engine",
+ "wasmer-object",
+ "wasmer-types",
+ "wasmer-vm",
+ "which",
+]
+
+[[package]]
+name = "wasmer-middlewares"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547baee2c0733cf436db7d137a8d1f86737a6321fc0fe6cd74caecf6f759c3c4"
+dependencies = [
+ "wasmer",
+ "wasmer-types",
+ "wasmer-vm",
+]
+
+[[package]]
+name = "wasmer-object"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf8e0c12b82ff81ebecd30d7e118be5fec871d6de885a90eeb105df0a769a7b"
+dependencies = [
+ "object 0.22.0",
+ "thiserror",
+ "wasmer-compiler",
+ "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-types"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f4ac28c2951cd792c18332f03da523ed06b170f5cf6bb5b1bdd7e36c2a8218"
+dependencies = [
+ "cranelift-entity",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "wasmer-vm"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7635ba0b6d2fd325f588d69a950ad9fa04dddbf6ad08b6b2a183146319bf6ae"
+dependencies = [
+ "backtrace",
+ "cc",
+ "cfg-if 0.1.10",
+ "indexmap",
+ "libc",
+ "memoffset",
+ "more-asserts",
+ "region",
+ "serde",
+ "thiserror",
+ "wasmer-types",
+ "winapi",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc2fe6350834b4e528ba0901e7aa405d78b89dc1fa3145359eb4de0e323fcf"
+
+[[package]]
+name = "wast"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9bbbd53432b267421186feee3e52436531fa69a7cfee9403f5204352df3dd05"
+dependencies = [
+ "leb128",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
+name = "wat"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab98ed25494f97c69f28758617f27c3e92e5336040b5c3a14634f2dd3fe61830"
+dependencies = [
+ "wast",
+]
+
+[[package]]
+name = "which"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
+dependencies = [
+ "either",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"

--- a/contracts/dynamic-caller-contract/Cargo.lock
+++ b/contracts/dynamic-caller-contract/Cargo.lock
@@ -62,6 +62,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 
@@ -308,6 +310,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4839a901843f3942576e65857f0ebf2e190ef7024d3c62a94099ba3f819ad1d"
 dependencies = [
  "der",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]

--- a/contracts/dynamic-caller-contract/Cargo.toml
+++ b/contracts/dynamic-caller-contract/Cargo.toml
@@ -33,3 +33,5 @@ thiserror = { version = "1.0.24" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }
+cosmwasm-vm = { path = "../../packages/vm", default-features = false, features = ["iterator"] }
+wasmer-types = { version = "1.0.2"}

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -1,12 +1,12 @@
 use cosmwasm_std::{
-    dynamic_link, entry_point, to_binary, to_vec, Binary, Deps, DepsMut, Env, MessageInfo,
+    dynamic_link, entry_point, to_vec, Binary, Deps, DepsMut, Env, MessageInfo,
     Response, StdResult, Uint128,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 use crate::error::ContractError;
-use crate::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
+use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 
 #[derive(Serialize, Deserialize)]
 pub struct ExampleStruct {
@@ -31,7 +31,7 @@ extern "C" {
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: InstantiateMsg,
 ) -> Result<Response, ContractError> {
     deps.storage
@@ -45,7 +45,7 @@ pub fn instantiate(
 pub fn execute(
     deps: DepsMut,
     _env: Env,
-    info: MessageInfo,
+    _info: MessageInfo,
     msg: ExecuteMsg,
 ) -> Result<Response, ContractError> {
     match msg {
@@ -53,7 +53,7 @@ pub fn execute(
     }
 }
 
-pub fn try_ping(deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractError> {
+pub fn try_ping(_deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractError> {
     let pong_ret = pong(ping_num.u128() as u64);
     let struct_ret = pong_with_struct(ExampleStruct {
         str_field: String::from("hello"),
@@ -67,6 +67,6 @@ pub fn try_ping(deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractEr
 }
 
 #[entry_point]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(_deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {}
 }

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -1,9 +1,9 @@
 use cosmwasm_std::{
-    entry_point, to_binary, to_vec, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult, dynamic_link,
-    Uint128,
+    dynamic_link, entry_point, to_binary, to_vec, Binary, Deps, DepsMut, Env, MessageInfo,
+    Response, StdResult, Uint128,
 };
-use std::fmt;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
 use crate::error::ContractError;
 use crate::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -16,12 +16,11 @@ pub struct ExampleStruct {
 impl fmt::Display for ExampleStruct {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{} {}", self.str_field, self.u64_field)
-    }    
+    }
 }
 
-
 #[dynamic_link(contract_name = "dynamic_callee_contract")]
-extern {
+extern "C" {
     fn pong(ping_num: u64) -> u64;
     fn pong_with_struct(example: ExampleStruct) -> ExampleStruct;
 }

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -1,36 +1,42 @@
+use cosmwasm_vm::testing::{mock_backend, Contract, MockInstanceOptions};
 use std::collections::HashMap;
-use wasmer_types::{Type, FunctionType};
-use cosmwasm_vm::testing::{Contract, mock_backend, MockInstanceOptions};
+use wasmer_types::{FunctionType, Type};
 
 static CONTRACT_CALLER: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/dynamic_caller_contract.wasm");
 
-
 fn required_imports() -> Vec<(String, FunctionType)> {
-    vec![(String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
-    (String::from("stub_pong_with_struct"), ([Type::I32], [Type::I32]).into()),]
+    vec![
+        (String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
+        (
+            String::from("stub_pong_with_struct"),
+            ([Type::I32], [Type::I32]).into(),
+        ),
+    ]
 }
-
 
 #[test]
 fn dynamic_link_import_works() {
     let options = MockInstanceOptions::default();
     let backend = mock_backend(&[]);
     let contract = Contract::from_code(CONTRACT_CALLER, backend, options).unwrap();
-    
-    let import_function_map: HashMap<_, _> = contract.module.imports().functions().map(|import|{
-        (import.name().to_string(), import.ty().clone())
-    }).collect::<Vec<(String, FunctionType)>>()
-    .into_iter()
-    .collect();
-    
+
+    let import_function_map: HashMap<_, _> = contract
+        .module
+        .imports()
+        .functions()
+        .map(|import| (import.name().to_string(), import.ty().clone()))
+        .collect::<Vec<(String, FunctionType)>>()
+        .into_iter()
+        .collect();
+
     let required_imports = required_imports();
     for required_export in required_imports {
         match import_function_map.get(&required_export.0) {
             Some(exported_function) => {
                 assert_eq!(*exported_function, required_export.1);
-            },
+            }
             None => assert!(false),
-        }  
+        }
     }
 }

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+use wasmer_types::{Type, FunctionType};
+use cosmwasm_vm::testing::{Contract, mock_backend, MockInstanceOptions};
+
+static CONTRACT_CALLER: &[u8] =
+    include_bytes!("../target/wasm32-unknown-unknown/release/dynamic_caller_contract.wasm");
+
+
+fn required_imports() -> Vec<(String, FunctionType)> {
+    vec![(String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
+    (String::from("stub_pong_with_struct"), ([Type::I32], [Type::I32]).into()),]
+}
+
+
+#[test]
+fn dynamic_link_import_works() {
+    let options = MockInstanceOptions::default();
+    let backend = mock_backend(&[]);
+    let contract = Contract::from_code(CONTRACT_CALLER, backend, options).unwrap();
+    
+    let import_function_map: HashMap<_, _> = contract.module.imports().functions().map(|import|{
+        (import.name().to_string(), import.ty().clone())
+    }).collect::<Vec<(String, FunctionType)>>()
+    .into_iter()
+    .collect();
+    
+    let required_imports = required_imports();
+    for required_export in required_imports {
+        match import_function_map.get(&required_export.0) {
+            Some(exported_function) => {
+                assert_eq!(*exported_function, required_export.1);
+            },
+            None => assert!(false),
+        }  
+    }
+}

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/hackatom/Cargo.lock
+++ b/contracts/hackatom/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/ibc-reflect-send/Cargo.lock
+++ b/contracts/ibc-reflect-send/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/ibc-reflect/Cargo.lock
+++ b/contracts/ibc-reflect/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/queue/Cargo.lock
+++ b/contracts/queue/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/reflect/Cargo.lock
+++ b/contracts/reflect/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/staking/Cargo.lock
+++ b/contracts/staking/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/contracts/voting-with-uuid/Cargo.lock
+++ b/contracts/voting-with-uuid/Cargo.lock
@@ -131,6 +131,8 @@ dependencies = [
 name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
+ "proc-macro-error",
+ "quote",
  "syn",
 ]
 

--- a/contracts/voting-with-uuid/Cargo.lock
+++ b/contracts/voting-with-uuid/Cargo.lock
@@ -132,6 +132,7 @@ name = "cosmwasm-derive"
 version = "0.14.0-0.4.0"
 dependencies = [
  "proc-macro-error",
+ "proc-macro2",
  "quote",
  "syn",
 ]

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
+quote = "1.0"
 
 [dev-dependencies]
 # Needed for testing docs

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
+proc-macro-error = { version = "1", default-features = false }
 
 [dev-dependencies]
 # Needed for testing docs

--- a/packages/derive/Cargo.toml
+++ b/packages/derive/Cargo.toml
@@ -17,6 +17,7 @@ default = []
 [dependencies]
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
+proc-macro2 = "1.0"
 proc-macro-error = { version = "1", default-features = false }
 
 [dev-dependencies]

--- a/packages/derive/src/callable_point.rs
+++ b/packages/derive/src/callable_point.rs
@@ -1,0 +1,71 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::utils::{collect_available_arg_types, get_return_len, make_typed_return};
+
+pub fn make_callable_point(function: syn::ItemFn) -> TokenStream {
+    let stub_func_name_ident = format_ident!("stub_{}", function.sig.ident);
+    let args_len = function.sig.inputs.len();
+
+    let arg_idents: Vec<_> = (0..args_len).map(|i| format_ident!("arg{}", i)).collect();
+    let vec_arg_idents: Vec<_> = (0..args_len)
+        .map(|i| format_ident!("vec_arg{}", i))
+        .collect();
+    let ptr_idents: Vec<_> = (0..args_len).map(|i| format_ident!("ptr{}", i)).collect();
+
+    let arg_types = collect_available_arg_types(&function.sig, "callable_point".to_string());
+    let renamed_param_defs: Vec<_> = (0..args_len)
+        .map(|i| {
+            let renamed_param_ident = format_ident!("ptr{}", i);
+            quote! { #renamed_param_ident: u32 }
+        })
+        .collect();
+    let typed_return = make_typed_return(&function.sig.output, "callable_point".to_string());
+
+    let call_origin_return =
+        make_call_origin_and_return(&function.sig.ident, args_len, &function.sig.output);
+
+    quote! {
+        #[cfg(target_arch = "wasm32")]
+        #[no_mangle]
+        extern "C" fn #stub_func_name_ident(#(#renamed_param_defs),*) #typed_return {
+            #(let #vec_arg_idents: Vec<u8> = unsafe { cosmwasm_std::memory::consume_region(#ptr_idents as *mut cosmwasm_std::memory::Region)};)*
+            #(let #arg_idents: #arg_types = cosmwasm_std::from_slice(&#vec_arg_idents).unwrap();)*
+            #call_origin_return
+        }
+    }
+}
+
+fn make_call_origin_and_return(
+    func_name_ident: &syn::Ident,
+    args_len: usize,
+    return_type: &syn::ReturnType,
+) -> TokenStream {
+    let arguments: Vec<_> = (0..args_len).map(|n| format_ident!("arg{}", n)).collect();
+    let return_len = get_return_len(return_type);
+
+    match return_len {
+        0 => quote! {#func_name_ident(#(#arguments),*);},
+        1 => {
+            quote! {
+                let result = #func_name_ident(#(#arguments),*);
+                let vec_result = cosmwasm_std::to_vec(&result).unwrap();
+                cosmwasm_std::memory::release_buffer(vec_result) as u32
+            }
+        }
+        _ => {
+            let results: Vec<_> = (0..return_len)
+                .map(|n| format_ident!("result{}", n))
+                .collect();
+            let vec_results: Vec<_> = (0..return_len)
+                .map(|n| format_ident!("vec_result{}", n))
+                .collect();
+
+            quote! {
+                let (#(#results),*) = #func_name_ident(#(#arguments),*);
+                #(let #vec_results = cosmwasm_std::to_vec(&#results).unwrap();)*
+                (#(cosmwasm_std::memory::release_buffer(#vec_results) as u32),*)
+            }
+        }
+    }
+}

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -1,0 +1,162 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::utils::{abort_by, collect_available_arg_types, get_return_len, make_typed_return};
+
+macro_rules! abort_by_dynamic_link {
+    ($span:expr, $($tts:tt)*) => {
+        abort_by!($span,"dynamic_link", $($tts)*)
+    };
+}
+
+pub fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
+    let name_value = match nested_meta {
+        syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => Some(name_value),
+        _ => abort_by_dynamic_link!(nested_meta, "contract_name must be a NameValue"),
+    };
+
+    match name_value {
+        Some(name_value) => {
+            if name_value.path.is_ident("contract_name") {
+                match &name_value.lit {
+                    syn::Lit::Str(literal) => literal.value(),
+                    _ => abort_by_dynamic_link!(
+                        name_value.lit,
+                        "contract_name value is not string literal"
+                    ),
+                }
+            } else {
+                abort_by_dynamic_link!(name_value.path, "only allowed the \"contract_name\"")
+            }
+        }
+        None => abort_by_dynamic_link!(nested_meta, "invliad attribute type"),
+    }
+}
+
+pub fn generate_import_contract_declaration(
+    contract_name: String,
+    exist_extern_block: syn::ItemForeignMod,
+) -> TokenStream {
+    let foreign_function_decls: Vec<&syn::ForeignItemFn> = exist_extern_block
+        .items
+        .iter()
+        .map(|foregin_item| match foregin_item {
+            syn::ForeignItem::Fn(item_fn) => item_fn,
+            _ => abort_by_dynamic_link!(foregin_item, "only function type is allowed."),
+        })
+        .collect();
+
+    let mut new_item = TokenStream::new();
+    new_item.extend(generate_extern_block(
+        contract_name,
+        &foreign_function_decls,
+    ));
+    for func_decl in foreign_function_decls {
+        new_item.extend(generate_serialization_func(func_decl));
+    }
+
+    new_item
+}
+
+fn generate_extern_block(
+    module_name: String,
+    origin_foreign_func_decls: &[&syn::ForeignItemFn],
+) -> TokenStream {
+    let redeclared_funcs = origin_foreign_func_decls.iter().map(|func_decl| {
+        let args_len = func_decl.sig.inputs.len();
+        let stub_func_name_ident = format_ident!("stub_{}", func_decl.sig.ident);
+        let renamed_param_defs: Vec<_> = (0..args_len)
+            .map(|i| {
+                let renamed_param_ident = format_ident!("ptr{}", i);
+                quote! { #renamed_param_ident: u32 }
+            })
+            .collect();
+        let typed_return = make_typed_return(&func_decl.sig.output, "dynamic_link".to_string());
+        quote! {
+            fn #stub_func_name_ident(#(#renamed_param_defs),*) #typed_return;
+        }
+    });
+
+    quote! {
+        #[link(wasm_import_module = #module_name)]
+        extern "C" {
+            #(#redeclared_funcs)*
+        }
+    }
+}
+
+//Defines a function that was originally imported to execute serialization and call to imported stub_xxx.
+fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenStream {
+    let func_name = &origin_func_decl.sig.ident;
+
+    let args_len = origin_func_decl.sig.inputs.len();
+    let arg_types = collect_available_arg_types(&origin_func_decl.sig, "dynamic_link".to_string());
+
+    let renamed_param_defs: Vec<_> = (0..args_len)
+        .map(|i| {
+            let renamed_arg_ident = format_ident!("arg{}", i);
+            let arg_type = arg_types[i];
+            quote! { #renamed_arg_ident: #arg_type }
+        })
+        .collect();
+    let arg_idents: Vec<_> = (0..args_len).map(|i| format_ident!("arg{}", i)).collect();
+    let vec_arg_idents: Vec<_> = (0..args_len)
+        .map(|i| format_ident!("vec_arg{}", i))
+        .collect();
+    let region_arg_idents: Vec<_> = (0..args_len)
+        .map(|i| format_ident!("region_arg{}", i))
+        .collect();
+
+    let return_types = &origin_func_decl.sig.output;
+    let call_stub_and_return =
+        make_call_stub_and_return(&func_name.to_string(), args_len, return_types);
+    quote! {
+        fn #func_name(#(#renamed_param_defs),*) #return_types {
+            #(let #vec_arg_idents = cosmwasm_std::to_vec(&#arg_idents).unwrap();)*
+            #(let #region_arg_idents = cosmwasm_std::memory::release_buffer(#vec_arg_idents) as u32;)*
+            unsafe {
+                #call_stub_and_return
+            }
+        }
+    }
+}
+
+fn make_call_stub_and_return(
+    func_name: &str,
+    args_len: usize,
+    return_type: &syn::ReturnType,
+) -> TokenStream {
+    let ident_func_name = format_ident!("stub_{}", func_name);
+    let arguments: Vec<_> = (0..args_len)
+        .map(|n| format_ident!("region_arg{}", n))
+        .collect();
+
+    let return_len = get_return_len(return_type);
+    match return_len {
+        0 => {
+            quote! {
+                #ident_func_name(#(#arguments),*);
+            }
+        }
+        1 => {
+            quote! {
+                let result = #ident_func_name(#(#arguments),*);
+                let vec_result = cosmwasm_std::memory::consume_region(result as *mut cosmwasm_std::memory::Region);
+                cosmwasm_std::from_slice(&vec_result).unwrap()
+            }
+        }
+        _ => {
+            let vec_results: Vec<_> = (0..return_len)
+                .map(|n| format_ident!("vec_result{}", n))
+                .collect();
+            let results: Vec<_> = (0..return_len)
+                .map(|n| format_ident!("result{}", n))
+                .collect();
+            quote! {
+                let (#(#results),*) = #ident_func_name(#(#arguments),*);
+                #(let #vec_results = cosmwasm_std::memory::consume_region(#results as *mut cosmwasm_std::memory::Region);)*
+                (#(cosmwasm_std::from_slice(&#vec_results).unwrap()),*)
+            }
+        }
+    }
+}

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -29,7 +29,7 @@ pub fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
                 abort_by_dynamic_link!(name_value.path, "only allowed the \"contract_name\"")
             }
         }
-        None => abort_by_dynamic_link!(nested_meta, "invliad attribute type"),
+        None => abort_by_dynamic_link!(nested_meta, "invalid attribute type"),
     }
 }
 

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -2,10 +2,12 @@
 extern crate syn;
 
 use proc_macro::TokenStream;
-use proc_macro_error::{abort, proc_macro_error};
-use quote::quote;
+use proc_macro_error::proc_macro_error;
 use std::str::FromStr;
 
+mod callable_point;
+mod dynamic_link;
+mod utils;
 /// This attribute macro generates the boilerplate required to call into the
 /// contract-specific logic from the entry-points to the Wasm module.
 ///
@@ -89,127 +91,15 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     item
 }
 
-macro_rules! abort_by {
-    ($span:expr, $by:expr, $($tts:tt)*) => {
-        abort!($span, $($tts)*;
-        note = format!("this error originates in the attribute macro `{}`", $by)
-    )
-    };
-}
-macro_rules! abort_by_dynamic_link {
-    ($span:expr, $($tts:tt)*) => {
-        abort_by!($span,"dynamic_link", $($tts)*)
-    };
-}
-
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn callable_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let cloned = item.clone();
     let function = parse_macro_input!(cloned as syn::ItemFn);
-    let name = function.sig.ident.to_string();
 
-    let args_len = function.sig.inputs.len();
-    let arg_types = collect_available_arg_types(&function.sig, "callable_point".to_string());
-
-    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32, "
-    let typed_ptrs = (0..args_len).fold(String::new(), |acc, i| format!("{}ptr{}: u32, ", acc, i));
-
-    // E.g. "let vec_arg0: Vec<u8> = unsafe { consume_region(ptr0 as *mut Region) };\n let vec_arg1 ..."
-    let vec_args = (0..args_len).fold(String::new(), |acc, i| {
-        format!("{}let vec_arg{}: Vec<u8> = unsafe {{ cosmwasm_std::memory::consume_region(ptr{} as *mut cosmwasm_std::memory::Region) }};", acc, i, i)
-    });
-
-    // E.g. "let arg0: $ArgType = from_slice(vec_arg0));\n let arg1: ..."
-    let converted_args = (0..args_len).fold(String::new(), |acc, i| {
-        let arg_type = arg_types[i];
-        format!(
-            "{}let arg{}: {} = cosmwasm_std::from_slice(&vec_arg{}).unwrap();",
-            acc,
-            i,
-            quote! {#arg_type}.to_string(),
-            i
-        )
-    });
-
-    let typed_return = make_typed_return(&function.sig.output, "callable_point".to_string());
-    let call_origin_return = make_call_origin_and_return(&name, args_len, &function.sig.output);
-
-    let new_code = format!(
-        r##"
-        // The stub function does not create a new module unlike entry_point macro.
-        // This is because the argument type cannot be found if you define it as a new module.
-        #[cfg(target_arch = "wasm32")]
-            #[no_mangle]
-            extern "C" fn stub_{name}({typed_ptrs}){typed_return} {{
-                {vec_args}
-                {converted_args}
-                {call_origin_return}
-            }}
-    "##,
-        name = name,
-        typed_ptrs = typed_ptrs,
-        typed_return = typed_return,
-        vec_args = vec_args,
-        converted_args = converted_args,
-        call_origin_return = call_origin_return,
-    );
-    let entry = TokenStream::from_str(&new_code).unwrap();
-    item.extend(entry);
+    let maked = callable_point::make_callable_point(function);
+    item.extend(TokenStream::from(maked));
     item
-}
-
-fn make_call_origin_and_return(
-    func_name: &str,
-    args_len: usize,
-    return_type: &syn::ReturnType,
-) -> String {
-    let pass_args = (0..args_len).fold(String::new(), |acc, i| format!("{}arg{}, ", acc, i));
-    let return_len = get_return_len(return_type);
-    match return_len {
-        0 => format!(
-            "{func_name}({pass_args});",
-            func_name = func_name,
-            pass_args = pass_args
-        ),
-        1 => {
-            format!(
-                "let result = {func_name}({pass_args});
-            let vec_result = cosmwasm_std::to_vec(&result).unwrap();
-            cosmwasm_std::memory::release_buffer(vec_result) as u32",
-                func_name = func_name,
-                pass_args = pass_args,
-            )
-        }
-        _ => {
-            let tuple_returns =
-                (0..return_len).fold(String::new(), |acc, i| format!("{}result{}, ", acc, i));
-            let vec_returns = (0..return_len).fold(String::new(), |acc, i| {
-                format!(
-                    "{}let vec_result{i} = cosmwasm_std::to_vec(&result{i}).unwrap();\n",
-                    acc,
-                    i = i
-                )
-            });
-            let tuple_from_slice_returns = (0..return_len).fold(String::new(), |acc, i| {
-                format!(
-                    "{}cosmwasm_std::memory::release_buffer(vec_result{}) as u32, ",
-                    acc, i
-                )
-            });
-            format!(
-                "let ({tuple_returns}) = {func_name}({pass_args});
-            {vec_returns}
-            ({tuple_from_slice_returns})
-            ",
-                func_name = func_name,
-                pass_args = pass_args,
-                tuple_returns = tuple_returns,
-                vec_returns = vec_returns,
-                tuple_from_slice_returns = tuple_from_slice_returns,
-            )
-        }
-    }
 }
 
 #[proc_macro_error]
@@ -220,221 +110,10 @@ pub fn dynamic_link(attr: TokenStream, item: TokenStream) -> TokenStream {
         panic!("too many attributes");
     }
 
-    let contract_name = parse_contract_name(&attr_args[0]);
-
-    generate_import_contract_declaration(contract_name, item)
-}
-
-fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
-    let name_value = match nested_meta {
-        syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => Some(name_value),
-        _ => abort_by_dynamic_link!(nested_meta, "contract_name must be a NameValue"),
-    };
-
-    match name_value {
-        Some(name_value) => {
-            if name_value.path.is_ident("contract_name") {
-                match &name_value.lit {
-                    syn::Lit::Str(literal) => literal.value(),
-                    _ => abort_by_dynamic_link!(
-                        name_value.lit,
-                        "contract_name value is not string literal"
-                    ),
-                }
-            } else {
-                abort_by_dynamic_link!(name_value.path, "only allowed the \"contract_name\"")
-            }
-        }
-        None => abort_by_dynamic_link!(nested_meta, "invliad attribute type"),
-    }
-}
-
-fn generate_import_contract_declaration(contract_name: String, item: TokenStream) -> TokenStream {
-    let extern_block = parse_macro_input!(item as syn::ItemForeignMod);
-    let foreign_function_decls: Vec<&syn::ForeignItemFn> = extern_block
-        .items
-        .iter()
-        .map(|foregin_item| match foregin_item {
-            syn::ForeignItem::Fn(item_fn) => item_fn,
-            _ => abort_by_dynamic_link!(foregin_item, "only function type is allowed."),
-        })
-        .collect();
-
-    let mut new_item = TokenStream::new();
-    new_item.extend(generate_extern_block(
+    let contract_name = dynamic_link::parse_contract_name(&attr_args[0]);
+    let exist_extern_block = parse_macro_input!(item as syn::ItemForeignMod);
+    TokenStream::from(dynamic_link::generate_import_contract_declaration(
         contract_name,
-        &foreign_function_decls,
-    ));
-    for func_decl in foreign_function_decls {
-        new_item.extend(generate_serialization_func(func_decl));
-    }
-
-    new_item
-}
-
-fn generate_extern_block(
-    module_name: String,
-    origin_foreign_func_decls: &[&syn::ForeignItemFn],
-) -> TokenStream {
-    let redeclared_funcs =
-        origin_foreign_func_decls
-            .iter()
-            .fold(String::new(), |acc, func_decl| {
-                let args_len = func_decl.sig.inputs.len();
-                let typed_ptrs =
-                    (0..args_len).fold(String::new(), |acc, i| format!("{}ptr{}: u32, ", acc, i));
-                let typed_return =
-                    make_typed_return(&func_decl.sig.output, "dynamic_link".to_string());
-
-                format!(
-                    "{}fn stub_{}({}){};\n",
-                    acc, func_decl.sig.ident, typed_ptrs, typed_return
-                )
-            });
-
-    let new_extern_block = format!(
-        r#"
-            #[link(wasm_import_module = "{module_name}")]
-            extern "C" {{
-            {redeclared_funcs}
-            }}
-        "#,
-        module_name = module_name,
-        redeclared_funcs = redeclared_funcs,
-    );
-
-    TokenStream::from_str(&new_extern_block).unwrap()
-}
-
-//Defines a function that was originally imported to execute serialization and call to imported stub_xxx.
-fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenStream {
-    let func_name = origin_func_decl.sig.ident.to_string();
-
-    let args_len = origin_func_decl.sig.inputs.len();
-    let arg_types = collect_available_arg_types(&origin_func_decl.sig, "dynamic_link".to_string());
-
-    let renamed_args = (0..args_len).fold(String::new(), |acc, i| {
-        let arg_type = arg_types[i];
-        format!("{}arg{}: {}, ", acc, i, quote!(#arg_type).to_string())
-    });
-
-    let vec_args = (0..args_len).fold(String::new(), |acc, i| {
-        format!(
-            "{}let vec_arg{} = cosmwasm_std::to_vec(&arg{}).unwrap();",
-            acc, i, i
-        )
-    });
-    let region_args = (0..args_len).fold(String::new(), |acc, i| {
-        format!(
-            "{}let region_arg{} = cosmwasm_std::memory::release_buffer(vec_arg{}) as u32;",
-            acc, i, i
-        )
-    });
-
-    let return_types = &origin_func_decl.sig.output;
-    let call_stub_and_return = make_call_stub_and_return(&func_name, args_len, return_types);
-    let replaced_new_code = format!(
-        r##"
-            //replace function for serialization
-            fn {func_name}({renamed_args}) {origin_return} {{
-                {vec_args}
-                {region_args}
-                unsafe {{
-                    {call_stub_and_return}
-                }}
-            }}
-        "##,
-        func_name = func_name,
-        renamed_args = renamed_args,
-        origin_return = quote!(#return_types).to_string(),
-        vec_args = vec_args,
-        region_args = region_args,
-        call_stub_and_return = call_stub_and_return,
-    );
-    TokenStream::from_str(&replaced_new_code).unwrap()
-}
-
-fn make_call_stub_and_return(
-    func_name: &str,
-    args_len: usize,
-    return_type: &syn::ReturnType,
-) -> String {
-    let pass_args = (0..args_len).fold(String::new(), |acc, i| format!("{}region_arg{}, ", acc, i));
-
-    let return_len = get_return_len(return_type);
-    match return_len {
-        0 => format!(
-            "stub_{func_name}({pass_args});",
-            func_name = func_name,
-            pass_args = pass_args
-        ),
-        1 => {
-            format!("let result = stub_{func_name}({pass_args});
-            let vec_result = cosmwasm_std::memory::consume_region(result as *mut cosmwasm_std::memory::Region);    
-            cosmwasm_std::from_slice(&vec_result).unwrap()",
-            func_name = func_name,
-            pass_args = pass_args,
-            )
-        }
-        _ => {
-            let tuple_returns =
-                (0..return_len).fold(String::new(), |acc, i| format!("{}result{}, ", acc, i));
-            let vec_returns = (0..return_len).fold(String::new(), |acc, i| {
-                format!("{}let vec_result{i} = cosmwasm_std::memory::consume_region(result{i} as *mut cosmwasm_std::memory::Region);\n", acc, i=i)
-            });
-            let tuple_from_slice_returns = (0..return_len).fold(String::new(), |acc, i| {
-                format!(
-                    "{}cosmwasm_std::from_slice(&vec_result{}).unwrap(), ",
-                    acc, i
-                )
-            });
-            format!(
-                "let ({tuple_returns}) = stub_{func_name}({pass_args});
-            {vec_returns}
-            ({tuple_from_slice_returns})
-            ",
-                func_name = func_name,
-                pass_args = pass_args,
-                tuple_returns = tuple_returns,
-                vec_returns = vec_returns,
-                tuple_from_slice_returns = tuple_from_slice_returns,
-            )
-        }
-    }
-}
-
-fn collect_available_arg_types(func_sig: &syn::Signature, by: String) -> Vec<&syn::Type> {
-    func_sig
-        .inputs
-        .iter()
-        .map(|arg| match arg {
-            syn::FnArg::Receiver(_) => abort_by!(arg, by, "method type is not allowed."),
-            syn::FnArg::Typed(arg_info) => match arg_info.ty.as_ref() {
-                syn::Type::BareFn(_) => {
-                    abort_by!(arg, by, "function type by parameter is not allowed.")
-                }
-                _ => arg_info.ty.as_ref(),
-            },
-        })
-        .collect()
-}
-
-fn make_typed_return(return_type: &syn::ReturnType, by: String) -> String {
-    let return_types_len = get_return_len(return_type);
-    match return_types_len {
-        0 => String::from(""),
-        1 => String::from(" -> u32"),
-        //TODO: see (https://github.com/line/cosmwasm/issues/156)
-        _ => abort_by!(return_type, by, "Cannot support returning tuple type yet"),
-        //_ => format!(" -> ({})", (0..return_types_len).fold(String::new(), |acc, _| format!("{}u32, ", acc))),
-    }
-}
-fn get_return_len(return_type: &syn::ReturnType) -> usize {
-    match return_type {
-        syn::ReturnType::Default => 0,
-        syn::ReturnType::Type(_, return_type) => match return_type.as_ref() {
-            syn::Type::Tuple(tuple) => tuple.elems.len(),
-            _ => 1,
-        },
-    }
+        exist_extern_block,
+    ))
 }

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -393,7 +393,7 @@ fn collect_available_arg_types(func_sig: &syn::Signature) -> Vec<&syn::Type> {
         .map(|arg| match arg {
             syn::FnArg::Receiver(_) => abort!(arg, "method type is not allowed."),
             syn::FnArg::Typed(arg_info) => match arg_info.ty.as_ref() {
-                syn::Type::BareFn(_) => abort!(arg, "callable_point: function type by parameter is not allowed."),
+                syn::Type::BareFn(_) => abort!(arg, "function type by parameter is not allowed."),
                 _ => arg_info.ty.as_ref(),
             },
         })

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -391,9 +391,9 @@ fn collect_available_arg_types(func_sig: &syn::Signature) -> Vec<&syn::Type> {
         .inputs
         .iter()
         .map(|arg| match arg {
-            syn::FnArg::Receiver(_) => abort!(arg, "method type are not allowed."),
+            syn::FnArg::Receiver(_) => abort!(arg, "method type is not allowed."),
             syn::FnArg::Typed(arg_info) => match arg_info.ty.as_ref() {
-                syn::Type::BareFn(_) => abort!(arg, "function type by parameter are not allowed."),
+                syn::Type::BareFn(_) => abort!(arg, "callable_point: function type by parameter is not allowed."),
                 _ => arg_info.ty.as_ref(),
             },
         })

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate syn;
 
+use proc_macro_error::{proc_macro_error, abort};
 use proc_macro::TokenStream;
 use quote::quote;
 use std::str::FromStr;
@@ -88,7 +89,7 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     item
 }
 
-
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn callable_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
     let cloned = item.clone();
@@ -196,7 +197,7 @@ fn make_call_origin_and_return(func_name: &String, args_len: usize, return_type:
 }
 
 
-
+#[proc_macro_error]
 #[proc_macro_attribute]
 pub fn dynamic_link(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr_args = parse_macro_input!(attr as syn::AttributeArgs);
@@ -399,7 +400,9 @@ fn make_typed_return(return_type: &syn::ReturnType) -> String {
     match return_types_len {
         0 => String::from(""),
         1 => String::from(" -> u32"),
-        _ => format!(" -> ({})", (0..return_types_len).fold(String::new(), |acc, _| format!("{}u32, ", acc))),
+        // https://github.com/line/cosmwasm/issues/156
+        _ => abort!(return_type, "Cannot support returning tuple type yet")
+        //_ => format!(" -> ({})", (0..return_types_len).fold(String::new(), |acc, _| format!("{}u32, ", acc))),
     }
 }
 fn get_return_len(return_type: &syn::ReturnType) -> usize {

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate syn;
 
 use proc_macro::TokenStream;
+use quote::quote;
 use std::str::FromStr;
 
 /// This attribute macro generates the boilerplate required to call into the
@@ -81,6 +82,78 @@ pub fn entry_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
         name = name,
         typed_ptrs = typed_ptrs,
         ptrs = ptrs
+    );
+    let entry = TokenStream::from_str(&new_code).unwrap();
+    item.extend(entry);
+    item
+}
+
+
+#[proc_macro_attribute]
+pub fn callable_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream {
+    let cloned = item.clone();
+    let function = parse_macro_input!(cloned as syn::ItemFn);
+    let name = function.sig.ident.to_string();
+
+
+    let args_len = function.sig.inputs.len();
+    let arg_types: Vec<&syn::Type> = function.sig.inputs.iter().map(|arg| {
+        match arg {
+            syn::FnArg::Receiver(_) => panic!("callable_point Method type are not allowed."),
+            syn::FnArg::Typed(arg_info) => {
+                match arg_info.ty.as_ref() {
+                    syn::Type::BareFn(_) => panic!("callable_point function type by parameter are not allowed."),
+                    _ => arg_info.ty.as_ref(),
+                }
+            }
+        }
+    }).collect();
+
+
+    // E.g. "ptr0: u32, ptr1: u32, ptr2: u32, "
+    let typed_ptrs = (0..args_len).fold(String::new(), |acc, i| format!("{}ptr{}: u32, ", acc, i));
+  
+    // E.g. "let vec_arg0: Vec<u8> = unsafe { consume_region(ptr0 as *mut Region) };\n let vec_arg1 ..."
+    let vec_args = (0..args_len).fold(String::new(), |acc, i| {
+        format!("{}let vec_arg{}: Vec<u8> = unsafe {{ cosmwasm_std::memory::consume_region(ptr{} as *mut cosmwasm_std::memory::Region) }};", acc, i, i)
+    });
+
+    // E.g. "let arg0: $ArgType = from_slice(vec_arg0));\n let arg1: ..."
+    let converted_args = (0..args_len).fold(String::new(), |acc, i| {
+        let arg_type = arg_types[i];
+        format!("{}let arg{}: {} = cosmwasm_std::from_slice(&vec_arg{}).unwrap();",
+        acc,
+        i,
+        quote!{#arg_type}.to_string(),
+        i
+        )
+    });
+
+    // E.g. "arg0, arg1, arg2, "
+    let pass_args = (0..args_len).fold(String::new(), |acc, i| format!("{}arg{}, ", acc, i));
+
+    let new_code = format!(
+        r##"
+        // The stub function does not create a new module unlike entry_point macro.
+        // This is because the argument type cannot be found if you define it as a new module.
+        #[cfg(target_arch = "wasm32")]
+            #[no_mangle]
+            extern "C" fn stub_{name}({typed_ptrs}) -> u32 {{
+                {vec_args}
+                {converted_args}
+
+                // call the original function
+                let result = {name}({pass_args});
+                let vec_result = cosmwasm_std::to_vec(&result).unwrap();
+                cosmwasm_std::memory::release_buffer(vec_result) as u32
+            }}
+    "##,
+        name = name,
+        typed_ptrs = typed_ptrs,
+        vec_args = vec_args,
+        converted_args = converted_args,
+        pass_args = pass_args,
+
     );
     let entry = TokenStream::from_str(&new_code).unwrap();
     item.extend(entry);

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -147,7 +147,7 @@ pub fn callable_point(_attr: TokenStream, mut item: TokenStream) -> TokenStream 
 }
 
 fn make_call_origin_and_return(
-    func_name: &String,
+    func_name: &str,
     args_len: usize,
     return_type: &syn::ReturnType,
 ) -> String {
@@ -209,20 +209,16 @@ pub fn dynamic_link(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let contract_name = parse_contract_name(&attr_args[0]);
 
-    let new_item = generate_import_contract_declaration(contract_name, item);
-    new_item
+    generate_import_contract_declaration(contract_name, item)
 }
 
 fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
     let name_value = match nested_meta {
-        syn::NestedMeta::Meta(meta) => match meta {
-            syn::Meta::NameValue(name_value) => Some(name_value),
-            _ => None,
-        },
-        _ => None,
+        syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => Some(name_value),
+        _ => abort!(nested_meta, "contract_name must be a NameValue"),
     };
 
-    let contract_name = match name_value {
+    match name_value {
         Some(name_value) => {
             if name_value.path.is_ident("contract_name") {
                 match &name_value.lit {
@@ -234,8 +230,7 @@ fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
             }
         }
         None => abort!(nested_meta, "invliad attribute type"),
-    };
-    contract_name
+    }
 }
 
 fn generate_import_contract_declaration(contract_name: String, item: TokenStream) -> TokenStream {
@@ -263,7 +258,7 @@ fn generate_import_contract_declaration(contract_name: String, item: TokenStream
 
 fn generate_extern_block(
     module_name: String,
-    origin_foreign_func_decls: &Vec<&syn::ForeignItemFn>,
+    origin_foreign_func_decls: &[&syn::ForeignItemFn],
 ) -> TokenStream {
     let redeclared_funcs =
         origin_foreign_func_decls
@@ -343,7 +338,7 @@ fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenSt
 }
 
 fn make_call_stub_and_return(
-    func_name: &String,
+    func_name: &str,
     args_len: usize,
     return_type: &syn::ReturnType,
 ) -> String {

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -8,6 +8,8 @@ macro_rules! abort_by {
     )
     };
 }
+//it's for cannot use #[macro_export] with proc_macro
+#[allow(clippy::single_component_path_imports)]
 pub(crate) use abort_by;
 
 pub fn collect_available_arg_types(func_sig: &syn::Signature, by: String) -> Vec<&syn::Type> {

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -22,6 +22,8 @@ pub fn collect_available_arg_types(func_sig: &syn::Signature, by: String) -> Vec
                 syn::Type::BareFn(_) => {
                     abort_by!(arg, by, "function type by parameter is not allowed.")
                 }
+                syn::Type::Reference(_) => abort_by!(arg, by, "reference type by parameter is not allowed."),
+                syn::Type::Ptr(_) => abort_by!(arg, by, "Ptr type by parameter is not allowed."),
                 _ => arg_info.ty.as_ref(),
             },
         })

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -11,7 +11,7 @@ macro_rules! abort_by {
 // it's for cannot use #[macro_export] with proc_macro
 // but, It occured false-positive by clippy, so avoid it.
 // https://github.com/rust-lang/rust-clippy/issues/1938
-#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
+#[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_attribute))]
 #[allow(clippy::single_component_path_imports)]
 pub(crate) use abort_by;
 

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -22,7 +22,9 @@ pub fn collect_available_arg_types(func_sig: &syn::Signature, by: String) -> Vec
                 syn::Type::BareFn(_) => {
                     abort_by!(arg, by, "function type by parameter is not allowed.")
                 }
-                syn::Type::Reference(_) => abort_by!(arg, by, "reference type by parameter is not allowed."),
+                syn::Type::Reference(_) => {
+                    abort_by!(arg, by, "reference type by parameter is not allowed.")
+                }
                 syn::Type::Ptr(_) => abort_by!(arg, by, "Ptr type by parameter is not allowed."),
                 _ => arg_info.ty.as_ref(),
             },

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -8,7 +8,10 @@ macro_rules! abort_by {
     )
     };
 }
-//it's for cannot use #[macro_export] with proc_macro
+// it's for cannot use #[macro_export] with proc_macro
+// but, It occured false-positive by clippy, so avoid it.
+// https://github.com/rust-lang/rust-clippy/issues/1938
+#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
 #[allow(clippy::single_component_path_imports)]
 pub(crate) use abort_by;
 

--- a/packages/derive/src/utils.rs
+++ b/packages/derive/src/utils.rs
@@ -1,0 +1,51 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+macro_rules! abort_by {
+    ($span:expr, $by:expr, $($tts:tt)*) => {
+        proc_macro_error::abort!($span, $($tts)*;
+        note = format!("this error originates in the attribute macro `{}`", $by)
+    )
+    };
+}
+pub(crate) use abort_by;
+
+pub fn collect_available_arg_types(func_sig: &syn::Signature, by: String) -> Vec<&syn::Type> {
+    func_sig
+        .inputs
+        .iter()
+        .map(|arg| match arg {
+            syn::FnArg::Receiver(_) => abort_by!(arg, by, "method type is not allowed."),
+            syn::FnArg::Typed(arg_info) => match arg_info.ty.as_ref() {
+                syn::Type::BareFn(_) => {
+                    abort_by!(arg, by, "function type by parameter is not allowed.")
+                }
+                _ => arg_info.ty.as_ref(),
+            },
+        })
+        .collect()
+}
+
+pub fn get_return_len(return_type: &syn::ReturnType) -> usize {
+    match return_type {
+        syn::ReturnType::Default => 0,
+        syn::ReturnType::Type(_, return_type) => match return_type.as_ref() {
+            syn::Type::Tuple(tuple) => tuple.elems.len(),
+            _ => 1,
+        },
+    }
+}
+
+pub fn make_typed_return(return_type: &syn::ReturnType, by: String) -> TokenStream {
+    let return_types_len = get_return_len(return_type);
+    match return_types_len {
+        0 => quote! {},
+        1 => quote! { -> u32 },
+        //TODO: see (https://github.com/line/cosmwasm/issues/156)
+        _ => abort_by!(return_type, by, "Cannot support returning tuple type yet"),
+        // _ => {
+        //     let returns = vec![quote! {u32}; return_types_len];
+        //     quote! { -> (#(#returns),*)}
+        // }
+    }
+}

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -73,7 +73,7 @@ pub use crate::uuid::{new_uuid, Uuid};
 mod exports;
 #[cfg(target_arch = "wasm32")]
 mod imports;
-#[cfg(target_arch = "wasm32")]
+
 pub mod memory; // Used by exports and imports only. This assumes pointers are 32 bit long, which makes it untestable on dev machines.
 
 #[cfg(target_arch = "wasm32")]

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -109,6 +109,6 @@ pub mod testing {
 
 // Re-exports
 
-pub use cosmwasm_derive::entry_point;
 pub use cosmwasm_derive::callable_point;
 pub use cosmwasm_derive::dynamic_link;
+pub use cosmwasm_derive::entry_point;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -110,3 +110,5 @@ pub mod testing {
 // Re-exports
 
 pub use cosmwasm_derive::entry_point;
+pub use cosmwasm_derive::callable_point;
+pub use cosmwasm_derive::dynamic_link;

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -74,7 +74,7 @@ mod exports;
 #[cfg(target_arch = "wasm32")]
 mod imports;
 #[cfg(target_arch = "wasm32")]
-mod memory; // Used by exports and imports only. This assumes pointers are 32 bit long, which makes it untestable on dev machines.
+pub mod memory; // Used by exports and imports only. This assumes pointers are 32 bit long, which makes it untestable on dev machines.
 
 #[cfg(target_arch = "wasm32")]
 pub use crate::exports::{do_execute, do_instantiate, do_migrate, do_query, do_reply, do_sudo};

--- a/packages/std/src/memory.rs
+++ b/packages/std/src/memory.rs
@@ -93,8 +93,10 @@ fn build_region_from_components(offset: u32, capacity: u32, length: u32) -> Box<
 /// Returns the address of the optional Region as an offset in linear memory,
 /// or zero if not present
 #[cfg(feature = "iterator")]
+#[allow(clippy::borrowed_box)]
 pub fn get_optional_region_address(region: &Option<&Box<Region>>) -> u32 {
     /// Returns the address of the Region as an offset in linear memory
+    #[allow(clippy::borrowed_box)]
     fn get_region_address(region: &Box<Region>) -> u32 {
         region.as_ref() as *const Region as u32
     }

--- a/packages/vm/src/backend.rs
+++ b/packages/vm/src/backend.rs
@@ -130,19 +130,18 @@ pub trait Storage {
 pub trait BackendApi: Copy + Clone + Send {
     fn canonical_address(&self, human: &str) -> BackendResult<Vec<u8>>;
     fn human_address(&self, canonical: &[u8]) -> BackendResult<String>;
-    fn contract_call<A,S,Q>(
+    fn contract_call<A, S, Q>(
         &self,
-        caller_env: &Environment<A,S,Q>,
+        caller_env: &Environment<A, S, Q>,
         contract_addr: &str,
         target_info: &FunctionMetadata,
         args: &[WasmerVal],
         gas: u64,
     ) -> BackendResult<Box<[WasmerVal]>>
     where
-    A: BackendApi + 'static,
-    S: Storage + 'static,
-    Q: Querier + 'static,
-    ;
+        A: BackendApi + 'static,
+        S: Storage + 'static,
+        Q: Querier + 'static;
 }
 
 pub trait Querier {

--- a/packages/vm/src/backend.rs
+++ b/packages/vm/src/backend.rs
@@ -7,8 +7,8 @@ use cosmwasm_std::{Binary, ContractResult, SystemResult};
 #[cfg(feature = "iterator")]
 use cosmwasm_std::{Order, Pair};
 
-use crate::FunctionMetadata;
-use crate::WasmerVal;
+use crate::environment::Environment;
+use crate::{FunctionMetadata, WasmerVal};
 
 #[derive(Copy, Clone, Debug)]
 pub struct GasInfo {
@@ -130,13 +130,19 @@ pub trait Storage {
 pub trait BackendApi: Copy + Clone + Send {
     fn canonical_address(&self, human: &str) -> BackendResult<Vec<u8>>;
     fn human_address(&self, canonical: &[u8]) -> BackendResult<String>;
-    fn contract_call(
+    fn contract_call<A,S,Q>(
         &self,
+        caller_env: &Environment<A,S,Q>,
         contract_addr: &str,
         target_info: &FunctionMetadata,
         args: &[WasmerVal],
         gas: u64,
-    ) -> BackendResult<Box<[WasmerVal]>>;
+    ) -> BackendResult<Box<[WasmerVal]>>
+    where
+    A: BackendApi + 'static,
+    S: Storage + 'static,
+    Q: Querier + 'static,
+    ;
 }
 
 pub trait Querier {

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -49,7 +49,7 @@ pub struct Instance<A: BackendApi, S: Storage, Q: Querier> {
     ///
     /// This instance should only be accessed via the Environment, which provides safe access.
     _inner: Box<WasmerInstance>,
-    env: Environment<A, S, Q>,
+    pub env: Environment<A, S, Q>,
     pub required_features: HashSet<String>,
 }
 

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -36,7 +36,8 @@ pub use crate::calls::{
 };
 pub use crate::checksum::Checksum;
 
-pub use crate::dynamic_link::{dynamic_link, FunctionMetadata, WasmerVal};
+pub use crate::dynamic_link::{dynamic_link, FunctionMetadata, WasmerVal, copy_region_vals_between_env};
+pub use crate::environment::Environment;
 pub use crate::errors::{
     CommunicationError, CommunicationResult, RegionValidationError, RegionValidationResult,
     VmError, VmResult,

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -36,7 +36,9 @@ pub use crate::calls::{
 };
 pub use crate::checksum::Checksum;
 
-pub use crate::dynamic_link::{dynamic_link, FunctionMetadata, WasmerVal, copy_region_vals_between_env};
+pub use crate::dynamic_link::{
+    copy_region_vals_between_env, dynamic_link, FunctionMetadata, WasmerVal,
+};
 pub use crate::environment::Environment;
 pub use crate::errors::{
     CommunicationError, CommunicationResult, RegionValidationError, RegionValidationResult,

--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -12,7 +12,7 @@ use super::result::{TestingError, TestingResult};
 use super::storage::MockStorage;
 
 pub struct Contract<'a> {
-    module: Module,
+    pub module: Module,
     backend: Option<Backend<MockApi, MockStorage, MockQuerier>>,
     options: MockInstanceOptions<'a>,
 }

--- a/packages/vm/src/testing/environment.rs
+++ b/packages/vm/src/testing/environment.rs
@@ -1,0 +1,23 @@
+use super::{MockApi, MockQuerier, MockStorage};
+use crate::Environment;
+use crate::conversion::ref_to_u32;
+use crate::memory::{write_region, read_region};
+use crate::VmResult;
+use crate::WasmerVal;
+
+pub fn write_data_to_mock_env(env: &Environment<MockApi, MockStorage, MockQuerier>, data: &[u8]) -> VmResult<u32> {
+    let result = env.call_function1("allocate", &[(data.len() as u32).into()])?;
+    let region_ptr = ref_to_u32(&result)?;
+    write_region(&env.memory(), region_ptr, data)?;
+    Ok(region_ptr)
+}
+
+
+pub fn read_data_from_mock_env(
+    env: &Environment<MockApi, MockStorage, MockQuerier>,
+    wasm_ptr: &WasmerVal,
+    size: usize,
+) -> VmResult<Vec<u8>> {
+    let region_ptr = ref_to_u32(wasm_ptr)?;
+    read_region(&env.memory(), region_ptr, size)
+}

--- a/packages/vm/src/testing/environment.rs
+++ b/packages/vm/src/testing/environment.rs
@@ -1,17 +1,19 @@
 use super::{MockApi, MockQuerier, MockStorage};
-use crate::Environment;
 use crate::conversion::ref_to_u32;
-use crate::memory::{write_region, read_region};
+use crate::memory::{read_region, write_region};
+use crate::Environment;
 use crate::VmResult;
 use crate::WasmerVal;
 
-pub fn write_data_to_mock_env(env: &Environment<MockApi, MockStorage, MockQuerier>, data: &[u8]) -> VmResult<u32> {
+pub fn write_data_to_mock_env(
+    env: &Environment<MockApi, MockStorage, MockQuerier>,
+    data: &[u8],
+) -> VmResult<u32> {
     let result = env.call_function1("allocate", &[(data.len() as u32).into()])?;
     let region_ptr = ref_to_u32(&result)?;
     write_region(&env.memory(), region_ptr, data)?;
     Ok(region_ptr)
 }
-
 
 pub fn read_data_from_mock_env(
     env: &Environment<MockApi, MockStorage, MockQuerier>,

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -3,8 +3,9 @@ use cosmwasm_std::{Addr, BlockInfo, Coin, ContractInfo, Env, MessageInfo, Timest
 
 use super::querier::MockQuerier;
 use super::storage::MockStorage;
-use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo};
+use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo, Storage, Querier,};
 use crate::{FunctionMetadata, WasmerVal};
+use crate::environment::Environment;
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 const DEFAULT_GAS_COST_HUMANIZE: u64 = 44;
@@ -149,13 +150,19 @@ impl BackendApi for MockApi {
         };
         (result, gas_info)
     }
-    fn contract_call(
+    fn contract_call<A, S, Q>(
         &self,
+        _: &Environment<A, S, Q>,
         _: &str,
         _: &FunctionMetadata,
         _: &[WasmerVal],
         _: u64,
-    ) -> BackendResult<Box<[WasmerVal]>> {
+    ) -> BackendResult<Box<[WasmerVal]>> 
+    where
+    A: BackendApi + 'static,
+    S: Storage + 'static,
+    Q: Querier + 'static,
+    {
         panic!("get_contract_call for the mock will be filled later")
     }
 }

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -3,9 +3,9 @@ use cosmwasm_std::{Addr, BlockInfo, Coin, ContractInfo, Env, MessageInfo, Timest
 
 use super::querier::MockQuerier;
 use super::storage::MockStorage;
-use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo, Storage, Querier,};
-use crate::{FunctionMetadata, WasmerVal};
 use crate::environment::Environment;
+use crate::{Backend, BackendApi, BackendError, BackendResult, GasInfo, Querier, Storage};
+use crate::{FunctionMetadata, WasmerVal};
 
 pub const MOCK_CONTRACT_ADDR: &str = "cosmos2contract";
 const DEFAULT_GAS_COST_HUMANIZE: u64 = 44;
@@ -157,11 +157,11 @@ impl BackendApi for MockApi {
         _: &FunctionMetadata,
         _: &[WasmerVal],
         _: u64,
-    ) -> BackendResult<Box<[WasmerVal]>> 
+    ) -> BackendResult<Box<[WasmerVal]>>
     where
-    A: BackendApi + 'static,
-    S: Storage + 'static,
-    Q: Querier + 'static,
+        A: BackendApi + 'static,
+        S: Storage + 'static,
+        Q: Querier + 'static,
     {
         panic!("get_contract_call for the mock will be filled later")
     }

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -2,16 +2,17 @@
 
 mod calls;
 mod contract;
+mod environment;
 mod ibc_calls;
 mod instance;
 mod mock;
 mod querier;
 mod result;
 mod storage;
-mod environment;
 
 pub use calls::{execute, instantiate, migrate, query, reply, sudo};
 pub use contract::Contract;
+pub use environment::{read_data_from_mock_env, write_data_to_mock_env};
 #[cfg(feature = "stargate")]
 pub use ibc_calls::{
     ibc_channel_close, ibc_channel_connect, ibc_channel_open, ibc_packet_ack, ibc_packet_receive,
@@ -28,4 +29,3 @@ pub use mock::{
 pub use querier::MockQuerier;
 pub use result::{TestingError, TestingResult};
 pub use storage::MockStorage;
-pub use environment::{read_data_from_mock_env, write_data_to_mock_env};

--- a/packages/vm/src/testing/mod.rs
+++ b/packages/vm/src/testing/mod.rs
@@ -8,6 +8,7 @@ mod mock;
 mod querier;
 mod result;
 mod storage;
+mod environment;
 
 pub use calls::{execute, instantiate, migrate, query, reply, sudo};
 pub use contract::Contract;
@@ -27,3 +28,4 @@ pub use mock::{
 pub use querier::MockQuerier;
 pub use result::{TestingError, TestingResult};
 pub use storage::MockStorage;
+pub use environment::{read_data_from_mock_env, write_data_to_mock_env};


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes #153 
- Add `#[callable_point]` that supports the easy function export and deserialize passed args internally.
- Add `#[dynamic_link]` that supports the easy function import and serialize the passing args internally.
- Add above serialized data copy function on VM host side. (with wasmvm)
 
please note: 
- no longer need to use an unsafe keyword when calling.
- Can't support tuple return yet. Dynamic linking is limited to one return value now. (https://github.com/line/cosmwasm/issues/156)



And, Please The `dynamic_link` poc PR(#153) first. This PR is based on #153.
#153 must be merged first before this PR can be reviewed.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
