### PR TITLE
fix: update rust version in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./
         run: |
           echo "Checking all contracts under ./artifacts"
-          docker run --volumes-from with_code rust:1.54.0 /bin/bash -e -c 'cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
+          docker run --volumes-from with_code rust:1.57.0 /bin/bash -e -c 'cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
           docker cp with_code:/code/artifacts .
 
       - name: Create Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@
 
 ### Features
 
-* Add derive macro "IntoEvent" ([#161](https://github.com/line/cosmwasm/issues/161))
-* merge original version 0.16.3 ([#148](https://github.com/line/cosmwasm/issues/148))
-* support Uuid type and sha1_calculate API ([#145](https://github.com/line/cosmwasm/issues/145))
-* Add release automation config ([#108](https://github.com/line/cosmwasm/issues/108))
+* Add derive macro "IntoEvent" ([#161](https://github.com/line/cosmwasm/pull/161))
+* merge original version 0.16.3 ([#148](https://github.com/line/cosmwasm/pull/148))
+* support Uuid type and sha1_calculate API ([#145](https://github.com/line/cosmwasm/pull/145))
+* Add release automation config ([#108](https://github.com/line/cosmwasm/pull/108))
 
 ### Fixes
 
-* export vm::testing::contract::Contract ([#147](https://github.com/line/cosmwasm/issues/147))
-* export DivideByZeroError to pub ([#140](https://github.com/line/cosmwasm/issues/140))
+* update rust version in release.yml ([#163](https://github.com/line/cosmwasm/pull/163))
+   - change the MSRV (Minimum Supported Rust Version) to 1.57.0
+* export vm::testing::contract::Contract ([#147](https://github.com/line/cosmwasm/pull/147))
+* export DivideByZeroError to pub ([#140](https://github.com/line/cosmwasm/pull/140))
 
 ## [[v0.14.0-0.4.0](https://github.com/line/cosmwasm/compare/v0.14.0-0.3.0...v0.14.0-0.4.0)] - 2021-06-28
 


### PR DESCRIPTION
# Description
github action's release.yml fails because the used rust version is old.
https://github.com/line/cosmwasm/runs/5390425201?check_suite_focus=true
This PR updates the version.
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (Not needed)
- [ ] I have added tests to cover my changes. (Not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
