### PR TITLE
fix: exclude floaty from release checking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./
         run: |
           echo "Checking all contracts under ./artifacts"
-          docker run --volumes-from with_code rust:1.57.0 /bin/bash -e -c 'cd ./code/packages/vm; ./examples/check_contract.sh ../../artifacts/*.wasm'
+          docker run --volumes-from with_code rust:1.57.0 /bin/bash -e -c 'cd ./code/packages/vm; export GLOBIGNORE=../../artifacts/floaty.wasm; ./examples/check_contract.sh ../../artifacts/*.wasm; export GLOBIGNORE='
           docker cp with_code:/code/artifacts .
 
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         working-directory: ./
         run: |
           echo "Checking all contracts under ./artifacts"
-          docker run --volumes-from with_code rust:1.57.0 /bin/bash -e -c 'cd ./code/packages/vm; export GLOBIGNORE=../../artifacts/floaty.wasm; ./examples/check_contract.sh ../../artifacts/*.wasm; export GLOBIGNORE='
+          docker run --volumes-from with_code rust:1.57.0 /bin/bash -e -c 'cd ./code/packages/vm; export GLOBIGNORE=../../artifacts/floaty.wasm; ./examples/check_contract.sh ../../artifacts/*.wasm'
           docker cp with_code:/code/artifacts .
 
       - name: Create Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+* exclude floaty from release checking ([#165](https://github.com/line/cosmwasm/pull/165))
 * update rust version in release.yml ([#163](https://github.com/line/cosmwasm/pull/163))
    - change the MSRV (Minimum Supported Rust Version) to 1.57.0
 * export vm::testing::contract::Contract ([#147](https://github.com/line/cosmwasm/pull/147))


### PR DESCRIPTION
# Description
Excluding floaty from release checking. It fixes a missing in #160.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (Not Needed)
- [ ] I have added tests to cover my changes. (Not Needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
