### PR TITLE
fix: modify the chglog template to filter commits and correct PRs' URL

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -6,7 +6,7 @@
 {{ range .CommitGroups -}}
 ### {{ .Title }}
 {{ range .Commits -}}{{ if regexMatch `^.+\(\[#[1-9][0-9]*\]\(https://github.com/line/cosmwasm/issues/[1-9][0-9]*\)\)$` .Subject }}
-* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}{{ end }}{{ end }}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ mustRegexReplaceAll `issues/([1-9][0-9]*)\)\)$` .Subject `pull/${1}))` }}{{ end }}{{ end }}
 
 {{ end -}}
 

--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -5,10 +5,9 @@
 
 {{ range .CommitGroups -}}
 ### {{ .Title }}
+{{ range .Commits -}}{{ if regexMatch `^.+\(\[#[1-9][0-9]*\]\(https://github.com/line/cosmwasm/issues/[1-9][0-9]*\)\)$` .Subject }}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}{{ end }}{{ end }}
 
-{{ range .Commits -}}
-* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{ end }}
 {{ end -}}
 
 {{- if .NoteGroups -}}

--- a/devtools/update_changelog.sh
+++ b/devtools/update_changelog.sh
@@ -11,3 +11,5 @@ CHANGELOG=$1
 tail +3 "$CHANGELOG" >tmpfile &&
   "$(dirname "$0")/generate_changelog.sh" "$VERSION" | cat - tmpfile >"$CHANGELOG"
 rm tmpfile
+
+echo "Note: This adds only \"Squash and merge\" PRs. Add \"Create a merge commit\" PRs (e.g. merging upstream) manually." >&2


### PR DESCRIPTION
# Description
This PR modifies chaglog template to

- filter commits that are not generated with "squash and merge" merging
- correct generating URLs for PR from `https://.../issues/XXX` to `https://.../pull/XXX`  in the suffix of PRs' title

And, modify to print a note to devtools/update_changelog.sh

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes #164

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (Not Needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
