### PR TITLE
feat: add memory_limit arg to some Contract's functions

### DIFF
--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -3,8 +3,8 @@ use wasmer::Module;
 use crate::backend::Backend;
 use crate::compatibility::check_wasm;
 use crate::instance::Instance;
-use crate::wasm_backend::compile;
 use crate::size::Size;
+use crate::wasm_backend::compile;
 
 use super::instance::MockInstanceOptions;
 use super::mock::MockApi;
@@ -30,7 +30,7 @@ impl<'a> Contract<'a> {
         wasm: &[u8],
         backend: Backend<MockApi, MockStorage, MockQuerier>,
         options: MockInstanceOptions<'a>,
-        memory_limit: Option<Size>
+        memory_limit: Option<Size>,
     ) -> TestingResult<Self> {
         check_wasm(wasm, &options.supported_features)?;
         let module = compile(wasm, memory_limit)?;
@@ -116,7 +116,8 @@ mod test {
     fn test_sanity_integration_test_flow() {
         let options = MockInstanceOptions::default();
         let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
+        let mut contract =
+            Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
 
         // common env/info
         let env = mock_env();
@@ -206,7 +207,8 @@ mod test {
     fn test_err_call_generate_instance_twice() {
         let options = MockInstanceOptions::default();
         let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
+        let mut contract =
+            Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
 
         // generate_instance
         let _instance = contract.generate_instance().unwrap();
@@ -220,7 +222,8 @@ mod test {
     fn test_err_call_recycle_before_generate_instance() {
         let options = MockInstanceOptions::default();
         let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
+        let mut contract =
+            Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options, None).unwrap();
 
         // make a dummy instance
         let dummy_instance = mock_instance(CONTRACT_WITHOUT_MIGRATE, &[]);


### PR DESCRIPTION
# Description
Add memory_limit arg to some of Contract's functions. It limits memory when compiling WASM code.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
