### PR TITLE
feat: simplify vm::testing::Contract

### DIFF
--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -11,6 +11,7 @@ use super::querier::MockQuerier;
 use super::result::{TestingError, TestingResult};
 use super::storage::MockStorage;
 
+#[derive(Clone)]
 pub struct Contract {
     module: Module,
     storage: MockStorage,

--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -1,6 +1,6 @@
 use wasmer::Module;
 
-use crate::backend::Backend;
+use crate::backend::{Backend, Storage};
 use crate::compatibility::check_wasm;
 use crate::instance::Instance;
 use crate::wasm_backend::compile;
@@ -80,6 +80,14 @@ impl Contract {
         })?;
         self.storage = backend.storage;
         Ok(())
+    }
+
+    /// get value from storage
+    pub fn raw_get(
+        &self,
+        key: &[u8],
+    ) -> Option<Vec<u8>> {
+        self.storage.get(key).0.unwrap()
     }
 }
 

--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -11,32 +11,26 @@ use super::querier::MockQuerier;
 use super::result::{TestingError, TestingResult};
 use super::storage::MockStorage;
 
-pub struct Contract<'a> {
+pub struct Contract {
     module: Module,
-    backend: Option<Backend<MockApi, MockStorage, MockQuerier>>,
-    options: MockInstanceOptions<'a>,
+    storage: MockStorage,
 }
-
-const ERR_GENERATE_INSTANCE_TWICE: &str = "generate_instance is called twice without called recycle. After generate_instance in called, Contract::recycle needs to be called before generate_instance is called the next time.";
-const ERR_RECYCLE_BEFORE_GENERATE_INSTANCE: &str = "recycle_instance is called before generate_instance. The parameter instance of the recycle_instance should be created with Contract::generate_instance of the same Contract.";
 
 /// representing a contract in integration test
 ///
 /// This enables tests instantiate a new instance every time testing call_(instantiate/execute/query/migrate) like actual wasmd's behavior.
 /// This is like Cache but it is for single contract and cannot save data in disk.
-impl<'a> Contract<'a> {
+impl Contract {
     pub fn from_code(
         wasm: &[u8],
-        backend: Backend<MockApi, MockStorage, MockQuerier>,
-        options: MockInstanceOptions<'a>,
+        options: &MockInstanceOptions,
     ) -> TestingResult<Self> {
         check_wasm(wasm, &options.supported_features)?;
         let module = compile(wasm, None)?;
-        let backend = Some(backend);
+        let storage = MockStorage::new();
         let contract = Self {
             module,
-            backend,
-            options,
+            storage,
         };
         Ok(contract)
     }
@@ -44,56 +38,47 @@ impl<'a> Contract<'a> {
     /// change the wasm code for testing migrate
     ///
     /// call this before `generate_instance` for testing `call_migrate`.
-    pub fn change_wasm(&mut self, wasm: &[u8]) -> TestingResult<()> {
-        check_wasm(wasm, &self.options.supported_features)?;
+    pub fn change_wasm(&mut self, wasm: &[u8], options:&MockInstanceOptions) -> TestingResult<()> {
+        check_wasm(wasm, &options.supported_features)?;
         let module = compile(wasm, None)?;
         self.module = module;
         Ok(())
     }
 
     /// generate instance for testing
-    ///
-    /// once this is called, result instance needs to be recycled by Contract::recycle_instance to generate new instance next time.
     pub fn generate_instance(
-        &mut self,
+        &self,
+        api: MockApi,
+        querier: MockQuerier,
+        options: &MockInstanceOptions,
     ) -> TestingResult<Instance<MockApi, MockStorage, MockQuerier>> {
-        let backend = self
-            .backend
-            .take()
-            .ok_or_else(|| TestingError::ContractError(ERR_GENERATE_INSTANCE_TWICE.to_string()))?;
+        let storage = self.storage.clone();
+        let backend = Backend {
+            api,
+            storage,
+            querier,
+        };
         let instance = Instance::from_module(
             &self.module,
             backend,
-            self.options.gas_limit,
-            self.options.print_debug,
+            options.gas_limit,
+            options.print_debug,
         )?;
         Ok(instance)
     }
 
-    /// recycle passed instance and take the ownership of the backend
-    ///
-    /// instance of a contract must be singleton and this is for recycling the instance.
-    pub fn recycle_instance(
+    /// update storage via instance recycling
+    pub fn update_storage(
         &mut self,
         instance: Instance<MockApi, MockStorage, MockQuerier>,
     ) -> TestingResult<()> {
-        if self.backend.is_some() {
-            return Err(TestingError::ContractError(
-                ERR_RECYCLE_BEFORE_GENERATE_INSTANCE.to_string(),
-            ));
-        };
         let backend = instance.recycle().ok_or_else(|| {
             TestingError::ContractError(
                 "Cannot recycle the instance with cosmwasm_vm::Instance::recycle".to_string(),
             )
         })?;
-        self.backend = Some(backend);
+        self.storage = backend.storage;
         Ok(())
-    }
-
-    /// change options
-    pub fn change_options(&mut self, options: MockInstanceOptions<'a>) {
-        self.options = options
     }
 }
 
@@ -102,7 +87,7 @@ impl<'a> Contract<'a> {
 mod test {
     use super::*;
     use crate::calls::{call_execute, call_instantiate, call_migrate, call_query};
-    use crate::testing::{mock_backend, mock_env, mock_info, mock_instance, MockInstanceOptions};
+    use crate::testing::{mock_env, mock_info, MockInstanceOptions};
     use cosmwasm_std::{QueryResponse, Response};
 
     static CONTRACT_WITHOUT_MIGRATE: &[u8] =
@@ -113,117 +98,104 @@ mod test {
     #[test]
     fn test_sanity_integration_test_flow() {
         let options = MockInstanceOptions::default();
-        let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options).unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, &options).unwrap();
 
         // common env/info
         let env = mock_env();
         let info = mock_info("sender", &[]);
 
         // init
-        let mut instance = contract.generate_instance().unwrap();
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{}".as_bytes();
         let _: Response = call_instantiate(&mut instance, &env, &info, msg)
             .unwrap()
             .into_result()
             .unwrap();
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // query and confirm the queue is empty
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"count\": {}}".as_bytes();
         let res: QueryResponse = call_query(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
         assert_eq!(res, "{\"count\":0}".as_bytes());
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // handle and enqueue 42
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"enqueue\": {\"value\": 42}}".as_bytes();
         let _: Response = call_execute(&mut instance, &env, &info, msg)
             .unwrap()
             .into_result()
             .unwrap();
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // query and confirm the length of the queue is 1
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"count\": {}}".as_bytes();
         let res: QueryResponse = call_query(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
         assert_eq!(res, "{\"count\":1}".as_bytes());
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // query and confirm the sum of the queue is 42
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"sum\": {}}".as_bytes();
         let res: QueryResponse = call_query(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
         assert_eq!(res, "{\"sum\":42}".as_bytes());
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // change the code and migrate
-        contract.change_wasm(CONTRACT_WITH_MIGRATE).unwrap();
-        let mut instance = contract.generate_instance().unwrap();
+        contract.change_wasm(CONTRACT_WITH_MIGRATE, &options).unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{}".as_bytes();
         let _: Response = call_migrate(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // query and check the length of the queue is 3
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"count\": {}}".as_bytes();
         let res: QueryResponse = call_query(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
         assert_eq!(res, "{\"count\":3}".as_bytes());
-        let _ = contract.recycle_instance(instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
 
         // query and check the sum of the queue is 303
-        let mut instance = contract.generate_instance().unwrap();
+        let api = MockApi::default();
+        let querier = MockQuerier::new(&[]);
+        let mut instance = contract.generate_instance(api, querier, &options).unwrap();
         let msg = "{\"sum\": {}}".as_bytes();
         let res: QueryResponse = call_query(&mut instance, &env, msg)
             .unwrap()
             .into_result()
             .unwrap();
         assert_eq!(res, "{\"sum\":303}".as_bytes());
-        let _ = contract.recycle_instance(instance).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "generate_instance is called twice")]
-    fn test_err_call_generate_instance_twice() {
-        let options = MockInstanceOptions::default();
-        let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options).unwrap();
-
-        // generate_instance
-        let _instance = contract.generate_instance().unwrap();
-
-        // should panic when call generate_instance before recycle
-        contract.generate_instance().unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "recycle_instance is called before generate_instance")]
-    fn test_err_call_recycle_before_generate_instance() {
-        let options = MockInstanceOptions::default();
-        let backend = mock_backend(&[]);
-        let mut contract = Contract::from_code(CONTRACT_WITHOUT_MIGRATE, backend, options).unwrap();
-
-        // make a dummy instance
-        let dummy_instance = mock_instance(CONTRACT_WITHOUT_MIGRATE, &[]);
-
-        // should panic when call recycle before generate_instance
-        contract.recycle_instance(dummy_instance).unwrap();
+        let _ = contract.update_storage(instance).unwrap();
     }
 }

--- a/packages/vm/src/testing/contract.rs
+++ b/packages/vm/src/testing/contract.rs
@@ -22,24 +22,18 @@ pub struct Contract {
 /// This enables tests instantiate a new instance every time testing call_(instantiate/execute/query/migrate) like actual wasmd's behavior.
 /// This is like Cache but it is for single contract and cannot save data in disk.
 impl Contract {
-    pub fn from_code(
-        wasm: &[u8],
-        options: &MockInstanceOptions,
-    ) -> TestingResult<Self> {
+    pub fn from_code(wasm: &[u8], options: &MockInstanceOptions) -> TestingResult<Self> {
         check_wasm(wasm, &options.supported_features)?;
         let module = compile(wasm, None)?;
         let storage = MockStorage::new();
-        let contract = Self {
-            module,
-            storage,
-        };
+        let contract = Self { module, storage };
         Ok(contract)
     }
 
     /// change the wasm code for testing migrate
     ///
     /// call this before `generate_instance` for testing `call_migrate`.
-    pub fn change_wasm(&mut self, wasm: &[u8], options:&MockInstanceOptions) -> TestingResult<()> {
+    pub fn change_wasm(&mut self, wasm: &[u8], options: &MockInstanceOptions) -> TestingResult<()> {
         check_wasm(wasm, &options.supported_features)?;
         let module = compile(wasm, None)?;
         self.module = module;
@@ -83,10 +77,7 @@ impl Contract {
     }
 
     /// get value from storage
-    pub fn raw_get(
-        &self,
-        key: &[u8],
-    ) -> Option<Vec<u8>> {
+    pub fn raw_get(&self, key: &[u8]) -> Option<Vec<u8>> {
         self.storage.get(key).0.unwrap()
     }
 }
@@ -172,7 +163,9 @@ mod test {
         let _ = contract.update_storage(instance).unwrap();
 
         // change the code and migrate
-        contract.change_wasm(CONTRACT_WITH_MIGRATE, &options).unwrap();
+        contract
+            .change_wasm(CONTRACT_WITH_MIGRATE, &options)
+            .unwrap();
         let api = MockApi::default();
         let querier = MockQuerier::new(&[]);
         let mut instance = contract.generate_instance(api, querier, &options).unwrap();

--- a/packages/vm/src/testing/storage.rs
+++ b/packages/vm/src/testing/storage.rs
@@ -20,13 +20,13 @@ const GAS_COST_LAST_ITERATION: u64 = 37;
 const GAS_COST_RANGE: u64 = 11;
 
 #[cfg(feature = "iterator")]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 struct Iter {
     data: Vec<Pair>,
     position: usize,
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub struct MockStorage {
     data: BTreeMap<Vec<u8>, Vec<u8>>,
     #[cfg(feature = "iterator")]


### PR DESCRIPTION
# Description
This PR simplifies `vm::testing::Contract` and makes it not take too much ownership of `Backend`.

This enables to specify the used querier and APIs in each generating instance from `Contract`. For example, using https://github.com/line/cosmwasm/pull/180 's `update_wasm` after constructing a contract needs this PR.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
