### PR TITLE
feat: add global api for to get env,deps in dynamic call

### DIFF
--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -1,5 +1,5 @@
 use cosmwasm_std::{
-    callable_point, entry_point, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    callable_point, entry_point, Binary, Deps, DepsMut, Env, GlobalApi, MessageInfo, Response,
     StdResult,
 };
 use serde::{Deserialize, Serialize};
@@ -29,12 +29,18 @@ pub struct ExampleStruct {
     pub str_field: String,
     pub u64_field: u64,
 }
+
 #[callable_point]
 fn pong_with_struct(example: ExampleStruct) -> ExampleStruct {
     ExampleStruct {
         str_field: example.str_field + " world",
         u64_field: example.u64_field + 1,
     }
+}
+
+#[callable_point]
+fn pong_env() -> Env {
+    GlobalApi::env()
 }
 
 // And declare a custom Error variant for the ones where you will want to make use of it

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -1,8 +1,9 @@
 use cosmwasm_std::{from_slice, to_vec, Addr, Env};
 use cosmwasm_vm::testing::{
-    mock_backend, mock_env, read_data_from_mock_env, write_data_to_mock_env, Contract,
-    MockInstanceOptions, MOCK_CONTRACT_ADDR,
+    mock_backend, mock_env, read_data_from_mock_env, write_data_to_mock_env, Contract, MockApi,
+    MockInstanceOptions, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR,
 };
+use cosmwasm_vm::Instance;
 use dynamic_callee_contract::contract::ExampleStruct;
 use std::collections::HashMap;
 use wasmer_types::{FunctionType, Type};
@@ -19,6 +20,18 @@ fn required_exports() -> Vec<(String, FunctionType)> {
         ),
         (String::from("stub_pong_env"), ([], [Type::I32]).into()),
     ]
+}
+
+fn make_callee_instance() -> Instance<MockApi, MockStorage, MockQuerier> {
+    let options = MockInstanceOptions::default();
+    let backend = mock_backend(&[]);
+    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
+    let instance = contract.generate_instance().unwrap();
+    instance
+        .env
+        .set_serialized_env(&to_vec(&mock_env()).unwrap());
+
+    instance
 }
 
 #[test]
@@ -49,10 +62,7 @@ fn callable_point_export_works() {
 
 #[test]
 fn callable_point_pong_works() {
-    let options = MockInstanceOptions::default();
-    let backend = mock_backend(&[]);
-    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
-    let instance = contract.generate_instance().unwrap();
+    let instance = make_callee_instance();
 
     let serialized_param = to_vec(&10u64).unwrap();
     let param_region_ptr = write_data_to_mock_env(&instance.env, &serialized_param).unwrap();
@@ -75,10 +85,7 @@ fn callable_point_pong_works() {
 
 #[test]
 fn callable_point_pong_with_struct_works() {
-    let options = MockInstanceOptions::default();
-    let backend = mock_backend(&[]);
-    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
-    let instance = contract.generate_instance().unwrap();
+    let instance = make_callee_instance();
 
     let serialized_param = to_vec(&ExampleStruct {
         str_field: String::from("hello"),
@@ -106,10 +113,7 @@ fn callable_point_pong_with_struct_works() {
 
 #[test]
 fn callable_point_pong_env_works() {
-    let options = MockInstanceOptions::default();
-    let backend = mock_backend(&[]);
-    let mut contract = Contract::from_code(CONTRACT_CALLEE, backend, options).unwrap();
-    let instance = contract.generate_instance().unwrap();
+    let instance = make_callee_instance();
 
     let required_exports = required_exports();
     instance

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -129,3 +129,26 @@ fn callable_point_pong_env_works() {
     let result: Env = from_slice(&serialized_return).unwrap();
     assert_eq!(result.contract.address, Addr::unchecked(MOCK_CONTRACT_ADDR));
 }
+
+
+
+
+#[test]
+fn callable_point_pong_deps_works() {
+    let instance = make_callee_instance();
+
+    let required_exports = required_exports();
+    let call_result = instance
+        .call_function_strict(
+            &required_exports[1].1,
+            "stub_pong_env",
+            &[],
+        )
+        .unwrap();
+    assert_eq!(call_result.len(), 1);
+
+    let serialized_return =
+        read_data_from_mock_env(&instance.env, &call_result[0], u32::MAX as usize).unwrap();
+    let result: Env = from_slice(&serialized_return).unwrap();
+    assert_eq!(result.contract.address, Addr::unchecked("cosmos2contract"));
+}

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    dynamic_link, entry_point, to_vec, Binary, Deps, DepsMut, Env, MessageInfo,
-    Response, StdResult, Uint128,
+    dynamic_link, entry_point, to_vec, Binary, Deps, DepsMut, Env, MessageInfo, Response,
+    StdResult, Uint128,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -23,6 +23,7 @@ impl fmt::Display for ExampleStruct {
 extern "C" {
     fn pong(ping_num: u64) -> u64;
     fn pong_with_struct(example: ExampleStruct) -> ExampleStruct;
+    fn pong_env() -> Env;
 }
 
 // Note, you can use StdResult in some functions where you do not
@@ -63,6 +64,10 @@ pub fn try_ping(_deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractE
     let mut res = Response::default();
     res.add_attribute("returned_pong", pong_ret.to_string());
     res.add_attribute("returned_pong_with_struct", struct_ret.to_string());
+    res.add_attribute(
+        "returned_contract_address",
+        pong_env().contract.address.to_string(),
+    );
     Ok(res)
 }
 

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -17,6 +17,11 @@ fn required_imports() -> Vec<(String, String, FunctionType)> {
             String::from("dynamic_callee_contract"),
             ([Type::I32], [Type::I32]).into(),
         ),
+        (
+            String::from("stub_pong_env"),
+            String::from("dynamic_callee_contract"),
+            ([], [Type::I32]).into(),
+        ),
     ]
 }
 

--- a/packages/std/src/global_api.rs
+++ b/packages/std/src/global_api.rs
@@ -2,7 +2,6 @@ use crate::memory::{consume_region, Region};
 use crate::serde::from_slice;
 use crate::Env;
 
-
 extern "C" {
     fn global_env() -> u32;
 }

--- a/packages/std/src/global_api.rs
+++ b/packages/std/src/global_api.rs
@@ -1,0 +1,17 @@
+use crate::memory::{consume_region, Region};
+use crate::serde::from_slice;
+use crate::Env;
+
+
+extern "C" {
+    fn global_env() -> u32;
+}
+
+pub struct GlobalApi {}
+impl GlobalApi {
+    pub fn env() -> Env {
+        let env_ptr = unsafe { global_env() };
+        let vec_env = unsafe { consume_region(env_ptr as *mut Region) };
+        from_slice(&vec_env).unwrap()
+    }
+}

--- a/packages/std/src/global_api.rs
+++ b/packages/std/src/global_api.rs
@@ -1,6 +1,10 @@
+#[cfg(target_arch = "wasm32")]
+use crate::exports::make_dependencies;
 use crate::memory::{consume_region, Region};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::mock::mock_dependencies;
 use crate::serde::from_slice;
-use crate::Env;
+use crate::{Deps, DepsMut, Env};
 
 extern "C" {
     fn global_env() -> u32;
@@ -12,5 +16,40 @@ impl GlobalApi {
         let env_ptr = unsafe { global_env() };
         let vec_env = unsafe { consume_region(env_ptr as *mut Region) };
         from_slice(&vec_env).unwrap()
+    }
+
+    // By existing design, ownership of Deps is intended to be held outside the contract logic.
+    // So, it is not possible to provide a simple getter style without changing the existing design.
+    pub fn with_deps<C, R>(callback: C) -> R
+    where
+        C: FnOnce(Deps) -> R,
+    {
+        /* FIXME:
+        In actual product execution, deps is a stateless implementation.
+        so even if we call make_dependencies in multiple places, there are no practical problems other than design violations.
+        However, mock_dependencies in the test environment is different.
+        Since it has an individual state, if it is created in several places, the test environment will be inconsistent with each different state.
+
+        Therefore, it is currently not possible to develop logic that tests dynamic_call and the existing message driven.
+        */
+        #[cfg(target_arch = "wasm32")]
+        let deps = make_dependencies();
+        #[cfg(not(target_arch = "wasm32"))]
+        let deps = mock_dependencies(&[]);
+
+        callback(deps.as_ref())
+    }
+
+    pub fn with_deps_mut<C, R>(callback: C) -> R
+    where
+        C: FnOnce(DepsMut) -> R,
+    {
+        // FIXME: same above
+        #[cfg(target_arch = "wasm32")]
+        let mut deps = make_dependencies();
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut deps = mock_dependencies(&[]);
+
+        callback(deps.as_mut())
     }
 }

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -23,6 +23,7 @@ mod timestamp;
 mod traits;
 mod types;
 mod uuid;
+mod global_api;
 
 #[allow(deprecated)]
 pub use crate::addresses::{Addr, CanonicalAddr, HumanAddr};
@@ -66,6 +67,7 @@ pub use crate::timestamp::Timestamp;
 pub use crate::traits::{Api, Querier, QuerierResult, QuerierWrapper, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo};
 pub use crate::uuid::{new_uuid, Uuid};
+pub use crate::global_api::GlobalApi;
 
 // Exposed in wasm build only
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -9,6 +9,7 @@ mod conversion;
 mod deps;
 mod entry_points;
 mod errors;
+mod global_api;
 mod ibc;
 mod import_helpers;
 #[cfg(feature = "iterator")]
@@ -23,7 +24,6 @@ mod timestamp;
 mod traits;
 mod types;
 mod uuid;
-mod global_api;
 
 #[allow(deprecated)]
 pub use crate::addresses::{Addr, CanonicalAddr, HumanAddr};
@@ -34,6 +34,7 @@ pub use crate::errors::{
     DivideByZeroError, OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult,
     SystemError, VerificationError,
 };
+pub use crate::global_api::GlobalApi;
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{
     IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
@@ -67,7 +68,6 @@ pub use crate::timestamp::Timestamp;
 pub use crate::traits::{Api, Querier, QuerierResult, QuerierWrapper, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo};
 pub use crate::uuid::{new_uuid, Uuid};
-pub use crate::global_api::GlobalApi;
 
 // Exposed in wasm build only
 

--- a/packages/vm/src/calls.rs
+++ b/packages/vm/src/calls.rs
@@ -144,6 +144,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "instantiate", &[env, info, msg], MAX_LENGTH_INIT)
 }
@@ -161,6 +162,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "execute", &[env, info, msg], MAX_LENGTH_EXECUTE)
 }
@@ -177,6 +179,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "migrate", &[env, msg], MAX_LENGTH_MIGRATE)
 }
@@ -193,6 +196,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "sudo", &[env, msg], MAX_LENGTH_SUDO)
 }
@@ -209,6 +213,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "reply", &[env, msg], MAX_LENGTH_SUBCALL_RESPONSE)
 }
@@ -225,6 +230,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(true);
     call_raw(instance, "query", &[env, msg], MAX_LENGTH_QUERY)
 }

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -27,6 +27,7 @@ const SUPPORTED_IMPORTS: &[&str] = &[
     "env.db_scan",
     #[cfg(feature = "iterator")]
     "env.db_next",
+    "env.global_env",
 ];
 
 /// Lists all entry points we expect to be present when calling a contract.

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -260,6 +260,20 @@ impl<A: BackendApi, S: Storage, Q: Querier> Environment<A, S, Q> {
         });
     }
 
+    pub fn get_serialized_env(&self) -> Vec<u8> {
+        self.with_context_data(|context_data| match &context_data.serialized_env {
+            Some(env) => Ok(env.clone()),
+            None => Err(VmError::uninitialized_context_data("serialized_env")),
+        })
+        .expect("serialized_env is not set. This is a bug in the lifecycle.")
+    }
+
+    pub fn set_serialized_env(&self, serialized_env: &[u8]) {
+        self.with_context_data_mut(|context_data| {
+            context_data.serialized_env = Some(serialized_env.to_vec());
+        });
+    }
+
     /// Returns true iff the storage is set to readonly mode
     pub fn is_storage_readonly(&self) -> bool {
         self.with_context_data(|context_data| context_data.storage_readonly)
@@ -367,6 +381,7 @@ pub struct ContextData<S: Storage, Q: Querier> {
     querier: Option<Q>,
     /// A non-owning link to the wasmer instance
     wasmer_instance: Option<NonNull<WasmerInstance>>,
+    serialized_env: Option<Vec<u8>>,
 }
 
 impl<S: Storage, Q: Querier> ContextData<S, Q> {
@@ -377,6 +392,7 @@ impl<S: Storage, Q: Querier> ContextData<S, Q> {
             storage_readonly: true,
             querier: None,
             wasmer_instance: None,
+            serialized_env: None,
         }
     }
 }

--- a/packages/vm/src/ibc_calls.rs
+++ b/packages/vm/src/ibc_calls.rs
@@ -133,6 +133,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(
         instance,
@@ -152,6 +153,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(
         instance,
@@ -171,6 +173,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(
         instance,
@@ -190,6 +193,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(
         instance,
@@ -209,6 +213,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(instance, "ibc_packet_ack", &[env, ack], MAX_LENGTH_IBC)
 }
@@ -223,6 +228,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
+    instance.env.set_serialized_env(env);
     instance.set_storage_readonly(false);
     call_raw(
         instance,

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -179,6 +179,12 @@ pub fn native_debug<A: BackendApi, S: Storage, Q: Querier>(
     Ok(())
 }
 
+pub fn native_env<A: BackendApi, S: Storage, Q: Querier>(
+    env: &Environment<A, S, Q>,
+) -> VmResult<u32> {
+    write_to_contract(env, &env.get_serialized_env())
+}
+
 //
 // Import implementations
 //

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -14,7 +14,7 @@ use crate::features::required_features_from_wasmer_instance;
 use crate::imports::{
     native_addr_canonicalize, native_addr_humanize, native_addr_validate, native_db_read,
     native_db_remove, native_db_write, native_debug, native_ed25519_batch_verify,
-    native_ed25519_verify, native_query_chain, native_secp256k1_recover_pubkey,
+    native_ed25519_verify, native_env, native_query_chain, native_secp256k1_recover_pubkey,
     native_secp256k1_verify, native_sha1_calculate,
 };
 #[cfg(feature = "iterator")]
@@ -210,6 +210,11 @@ where
         env_imports.insert(
             "db_next",
             Function::new_native_with_env(store, env.clone(), native_db_next),
+        );
+
+        env_imports.insert(
+            "global_env",
+            Function::new_native_with_env(store, env.clone(), native_env),
         );
 
         import_obj.register("env", env_imports);


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes https://github.com/line/wasmvm/pull/61 https://github.com/line/lbm-sdk/pull/500

Adds a global API instead of the env that was passed as a parameter.
A contract can obtain information by calling the global API.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
