### PR TITLE
fix: make query-queue's entry points using entry_points

### DIFF
--- a/contracts/query-queue/src/contract.rs
+++ b/contracts/query-queue/src/contract.rs
@@ -2,8 +2,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{
-    from_slice, to_binary, to_vec, Deps, DepsMut, Env, MessageInfo, QueryResponse, Response,
-    StdResult, Storage,
+    entry_point, from_slice, to_binary, to_vec, Deps, DepsMut, Env, MessageInfo, QueryResponse,
+    Response, StdResult, Storage,
 };
 
 use crate::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
@@ -59,7 +59,7 @@ fn read_queue_address(storage: &dyn Storage) -> String {
     config.queue_address
 }
 
-// A no-op, just empty data
+#[entry_point]
 pub fn instantiate(
     deps: DepsMut,
     _env: Env,
@@ -70,6 +70,7 @@ pub fn instantiate(
     Ok(Response::default())
 }
 
+#[entry_point]
 pub fn execute(
     deps: DepsMut,
     _env: Env,
@@ -86,6 +87,7 @@ fn handle_change_address(deps: DepsMut, address: String) -> StdResult<Response> 
     Ok(Response::default())
 }
 
+#[entry_point]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<QueryResponse> {
     match msg {
         QueryMsg::Raw { key } => to_binary(&query_raw(deps, key)?),


### PR DESCRIPTION
# Description
Before this PR, `query-queue`s entry point does not be exposed by `entry_points`. It causes an error while checking this contract.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes. (tests already exist)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
