### PR TITLE
fix: fix keys of action caches for contracts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_burner-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_burner-rust:1.57.0-${{ hashFiles('contracts/burner/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -251,7 +251,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_crypto_verify-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_crypto_verify-rust:1.57.0-${{ hashFiles('contracts/crypto-verify/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -297,7 +297,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-hackatom_verify-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_hackatom-rust:1.57.0-${{ hashFiles('contracts/hackatom/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -343,7 +343,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_ibc_reflect-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_ibc_reflect-rust:1.57.0-${{ hashFiles('contracts/ibc-reflect/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -389,7 +389,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_ibc_reflect_send-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_ibc_reflect_send-rust:1.57.0-${{ hashFiles('contracts/ibc-reflect-send/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -435,7 +435,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_queue-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_queue-rust:1.57.0-${{ hashFiles('contracts/queue/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -482,7 +482,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_query_queue-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_query_queue-rust:1.57.0-${{ hashFiles('contracts/queue/Cargo.lock', 'contracts/query-queue/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -531,7 +531,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_reflect-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_reflect-rust:1.57.0-${{ hashFiles('contracts/reflect/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target
@@ -577,7 +577,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-contract_staking-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-contract_staking-rust:1.57.0-${{ hashFiles('contracts/staking/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add wasm32 target

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -623,7 +623,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-fmt-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-fmt-rust:1.57.0-${{ hashFiles('Cargo.lock', 'contracts/*/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add rustfmt component
@@ -672,7 +672,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.cargo
-          key: cargocache-v2-clippy-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+          key: cargocache-v2-clippy-rust:1.57.0-${{ hashFiles('Cargo.lock', 'contracts/*/Cargo.lock') }}
       - name: Version information
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Add clippy component


### PR DESCRIPTION
# Description

Now, the key of action caches for contracts uses `cacheFiles('Cargo.lock')`. The `Cargo.toml` excludes `contracts/*`, so this key does not work well. This PR fix this to use `contracts/[contract-name]/Cargo.lock`.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
