### PR TITLE
fix: release action ends with success even if it does not renew tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
 
-env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -27,24 +25,20 @@ jobs:
         id: get_version
         run: |
             VERSION=$(./devtools/get_version.sh)
-            echo ::set-output name=version::$VERSION
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-      - name: Check version
-        id: tag_check
-        uses: dudo/tag_check@v1.1.1
-        with:
-          version: ${{ steps.get_version.outputs.version }}
-          git_tag_prefix: v
+            echo ::set-output name=version::v$VERSION
+      - name: Get latest tag
+        id: get_latest_tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
       - name: Create new tag
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         run: |
-          if [ -z "${{ steps.get_version.outputs.version }}" ]; then
-              git tag ${{ steps.get_version.outputs.version }}
-          fi
+          git tag ${{ steps.get_version.outputs.version }}
       - name: Install Docker client
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         run: |
           apk add docker-cli
       - name: Prepare volume with source code
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         run: |
           # create a dummy container which will hold a volume with config
           docker create -v /code --name with_code alpine /bin/true
@@ -54,10 +48,12 @@ jobs:
           docker cp ./contracts with_code:/code
           docker cp ./packages with_code:/code
       - name: Build development contracts
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         run: |
           echo "Building all contracts under ./contracts"
           docker run --volumes-from with_code cosmwasm/rust-optimizer:0.12.5 ./contracts/*/
       - name: Check development contracts
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         working-directory: ./
         run: |
           echo "Checking all contracts under ./artifacts"
@@ -65,10 +61,11 @@ jobs:
           docker cp with_code:/code/artifacts .
 
       - name: Create Release
+        if: ${{ steps.get_version.outputs.version != steps.get_latest_tag.outputs.tag }}
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: v${{ steps.get_version.outputs.version }}
+          tag_name: ${{ steps.get_version.outputs.version }}
           body: ${{ github.event.pull_request.body }}
           files: |
             ./artifacts/*


### PR DESCRIPTION
# Description
Without this PR, if the release action does not create a new tag, the action ends with failure even if nothing fails. This PR fixes it and makes release actions end with success.

https://github.com/loloicci/auto-tag-test is an example of how it works.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (NOT NEEDED)
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
