### PR TITLE
ci: fix broken workflow for benchmarking

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -39,3 +39,67 @@ jobs:
       - name: Run crypto benchmarks
         working-directory: ${{env.working-directory}}/crypto
         run: cargo bench -- --color never --save-baseline crypto
+
+  package_crypto:
+    name: package_crypto
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./packages/crypto
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.57.0
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo
+          key: cargocache-v2-package_crypto-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+      - name: Version information
+        run: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - name: Build
+        working-directory: ${{env.working-directory}}
+        run: cargo build --locked
+      - name: Run tests
+        working-directory: ${{env.working-directory}}
+        run: cargo test --locked
+
+  package_vm:
+    name: package_vm
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./packages/vm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.57.0
+          target: wasm32-unknown-unknown
+          profile: minimal
+          override: true
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo
+          key: cargocache-v2-package_vm-rust:1.57.0-${{ hashFiles('Cargo.lock') }}
+      - name: Version information
+        run: rustc --version; cargo --version; rustup --version; rustup target list --installed
+      - name: Build
+        working-directory: ${{env.working-directory}}
+        run: cargo build --locked
+      - name: Build with all features
+        working-directory: ${{env.working-directory}}
+        run: cargo build --locked --features iterator,staking,stargate
+      - name: Test
+        working-directory: ${{env.working-directory}}
+        run: cargo test --locked
+      - name: Test with all features
+        working-directory: ${{env.working-directory}}
+        run: cargo test --locked --features iterator,staking,stargate

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -7,12 +7,6 @@ on:
       - main
       - /^[0-9]+\.[0-9]+$/
       # 👇Add your branch here if benchmarking matters to your work
-      - benchmarking
-      - update-wasmer
-      - metering-restart
-      - load-wasm-speed
-      - cache-analyze
-      - fix-benches
 
 jobs:
   benchmarking:


### PR DESCRIPTION
# Description
Fix broken workflow for benchmarking.

The cause of the error is the lack of dependent tests of `package_vm` and `crypt packages`. This PR adds them.

Closes #208

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
