### PR TITLE
fix: limit exporting GlobalEnv only to wasm32 target

### DIFF
--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -9,7 +9,6 @@ mod conversion;
 mod deps;
 mod entry_points;
 mod errors;
-mod global_api;
 mod ibc;
 mod import_helpers;
 #[cfg(feature = "iterator")]
@@ -34,8 +33,6 @@ pub use crate::errors::{
     DivideByZeroError, OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult,
     SystemError, VerificationError,
 };
-#[cfg(target_arch = "wasm32")]
-pub use crate::global_api::GlobalApi;
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{
     IbcAcknowledgement, IbcBasicResponse, IbcChannel, IbcEndpoint, IbcMsg, IbcOrder, IbcPacket,
@@ -75,12 +72,16 @@ pub use crate::uuid::{new_uuid, Uuid};
 #[cfg(target_arch = "wasm32")]
 mod exports;
 #[cfg(target_arch = "wasm32")]
+mod global_api;
+#[cfg(target_arch = "wasm32")]
 mod imports;
 
 pub mod memory; // Used by exports and imports only. This assumes pointers are 32 bit long, which makes it untestable on dev machines.
 
 #[cfg(target_arch = "wasm32")]
 pub use crate::exports::{do_execute, do_instantiate, do_migrate, do_query, do_reply, do_sudo};
+#[cfg(target_arch = "wasm32")]
+pub use crate::global_api::GlobalApi;
 #[cfg(target_arch = "wasm32")]
 pub use crate::imports::{ExternalApi, ExternalQuerier, ExternalStorage};
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::errors::{
     DivideByZeroError, OverflowError, OverflowOperation, RecoverPubkeyError, StdError, StdResult,
     SystemError, VerificationError,
 };
+#[cfg(target_arch = "wasm32")]
 pub use crate::global_api::GlobalApi;
 #[cfg(feature = "stargate")]
 pub use crate::ibc::{


### PR DESCRIPTION
# Description
This PR limits exporting `GlobalEnv` only to wasm32 target.
Without this, the following error is caused during wasmvm's test for alpine linux.

```
# github.com/line/wasmvm/api
/usr/lib/gcc/x86_64-alpine-linux-musl/9.3.0/../../../../x86_64-alpine-linux-musl/bin/ld: api/libwasmvm_static.a(cosmwasm_std-bab964781d528372.cosmwasm_std.c8z0klf1-cgu.10.rcgu.o): in function `cosmwasm_std::global_api::GlobalApi::env':
cosmwasm_std.c8z0klf1-cgu.10:(.text._ZN12cosmwasm_std10global_api9GlobalApi3env17h764e247a0bf6c1faE+0x13): undefined reference to `global_env'
collect2: error: ld returned 1 exit status
make[1]: *** [release-build-alpine] Error 2
make: *** [release-build] Error 2
```

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (NOT NEEDED)
- [ ] I have added tests to cover my changes. (NOT NEEDED)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
