### PR TITLE
fix: remove chrono dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,16 +198,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,7 +295,6 @@ name = "cosmwasm-std"
 version = "1.0.0-0.6.0"
 dependencies = [
  "base64",
- "chrono",
  "cosmwasm-crypto",
  "cosmwasm-derive",
  "cosmwasm-schema",
@@ -1111,16 +1100,6 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
 
 [[package]]
 name = "num-traits"

--- a/packages/std/Cargo.toml
+++ b/packages/std/Cargo.toml
@@ -54,7 +54,5 @@ cosmwasm-crypto = { path = "../crypto", version = "1.0.0-0.6.0" }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../schema" }
-# The chrono dependency is only used in an example, which Rust compiles for us. If this causes trouble, remove it.
-chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 hex = "0.4"
 hex-literal = "0.3.1"


### PR DESCRIPTION
# Description
chrono has a security issue (https://github.com/chronotope/chrono/issues/499) and it is not fixed in the latest version.

We use chrono only in an example, so this PR removes chrono from the dependency.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
