### PR TITLE
feat: improve how to specify the callee contract address

### DIFF
--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -59,7 +59,7 @@ struct Me {
 }
 
 #[dynamic_link(Me)]
-trait Rentrance: Contract {
+trait ReEntrance: Contract {
     fn should_never_be_called(&self);
 }
 

--- a/contracts/dynamic-callee-contract/src/contract.rs
+++ b/contracts/dynamic-callee-contract/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    callable_point, dynamic_link, entry_point, to_vec, Addr, DepsMut, Env, GlobalApi, MessageInfo,
-    Response,
+    callable_point, dynamic_link, entry_point, Addr, Contract, DepsMut, Env, GlobalApi,
+    MessageInfo, Response,
 };
 use serde::{Deserialize, Serialize};
 
@@ -53,18 +53,20 @@ fn pong_env() -> Env {
     GlobalApi::env()
 }
 
-#[dynamic_link(contract_name = "dynamic_caller_contract")]
-extern "C" {
-    fn should_never_be_called();
+#[derive(Contract)]
+struct Me {
+    address: Addr,
+}
+
+#[dynamic_link(Me)]
+trait Rentrance: Contract {
+    fn should_never_be_called(&self);
 }
 
 #[callable_point]
-fn reentrancy(addr: Addr) {
-    GlobalApi::with_deps_mut(|deps| {
-        deps.storage
-            .set(b"dynamic_caller_contract", &to_vec(&addr).unwrap());
-    });
-    should_never_be_called()
+fn reentrancy(address: Addr) {
+    let me = Me { address };
+    me.should_never_be_called()
 }
 
 // And declare a custom Error variant for the ones where you will want to make use of it

--- a/contracts/dynamic-caller-contract/schema/query_msg.json
+++ b/contracts/dynamic-caller-contract/schema/query_msg.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
-  "type": "string",
-  "enum": []
+  "type": "object"
 }

--- a/contracts/dynamic-caller-contract/src/contract.rs
+++ b/contracts/dynamic-caller-contract/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
-    callable_point, dynamic_link, entry_point, to_vec, Addr, DepsMut, Env, MessageInfo, Response,
-    Uint128,
+    callable_point, dynamic_link, entry_point, from_slice, to_vec, Addr, Contract, DepsMut, Env,
+    MessageInfo, Response, Uint128,
 };
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -19,14 +19,19 @@ impl fmt::Display for ExampleStruct {
     }
 }
 
-#[dynamic_link(contract_name = "dynamic_callee_contract")]
-extern "C" {
-    fn pong(ping_num: u64) -> u64;
-    fn pong_with_struct(example: ExampleStruct) -> ExampleStruct;
-    fn pong_with_tuple(input: (String, i32)) -> (String, i32);
-    fn pong_with_tuple_takes_2_args(input1: String, input2: i32) -> (String, i32);
-    fn pong_env() -> Env;
-    fn reentrancy(addr: Addr);
+#[derive(Contract)]
+struct CalleeContract {
+    address: Addr,
+}
+
+#[dynamic_link(CalleeContract)]
+trait Callee: Contract {
+    fn pong(&self, ping_num: u64) -> u64;
+    fn pong_with_struct(&self, example: ExampleStruct) -> ExampleStruct;
+    fn pong_with_tuple(&self, input: (String, i32)) -> (String, i32);
+    fn pong_with_tuple_takes_2_args(&self, input1: String, input2: i32) -> (String, i32);
+    fn pong_env(&self) -> Env;
+    fn reentrancy(&self, addr: Addr);
 }
 
 // Note, you can use StdResult in some functions where you do not
@@ -54,18 +59,20 @@ pub fn execute(
 ) -> Result<Response, ContractError> {
     match msg {
         ExecuteMsg::Ping { ping_num } => try_ping(deps, ping_num),
-        ExecuteMsg::TryReEntrancy {} => try_re_entrancy(env),
+        ExecuteMsg::TryReEntrancy {} => try_re_entrancy(deps, env),
     }
 }
 
-pub fn try_ping(_deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractError> {
-    let pong_ret = pong(ping_num.u128() as u64);
-    let struct_ret = pong_with_struct(ExampleStruct {
+pub fn try_ping(deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractError> {
+    let address = from_slice(&deps.storage.get(b"dynamic_callee_contract").unwrap())?;
+    let contract = CalleeContract { address };
+    let pong_ret = contract.pong(ping_num.u128() as u64);
+    let struct_ret = contract.pong_with_struct(ExampleStruct {
         str_field: String::from("hello"),
         u64_field: 100u64,
     });
-    let tuple_ret = pong_with_tuple((String::from("hello"), 41));
-    let tuple_ret2 = pong_with_tuple_takes_2_args(String::from("hello"), 41);
+    let tuple_ret = contract.pong_with_tuple((String::from("hello"), 41));
+    let tuple_ret2 = contract.pong_with_tuple_takes_2_args(String::from("hello"), 41);
 
     let mut res = Response::default();
     res.add_attribute("returned_pong", pong_ret.to_string());
@@ -80,15 +87,17 @@ pub fn try_ping(_deps: DepsMut, ping_num: Uint128) -> Result<Response, ContractE
     );
     res.add_attribute(
         "returned_contract_address",
-        pong_env().contract.address.to_string(),
+        contract.pong_env().contract.address.to_string(),
     );
     Ok(res)
 }
 
-pub fn try_re_entrancy(env: Env) -> Result<Response, ContractError> {
+pub fn try_re_entrancy(deps: DepsMut, env: Env) -> Result<Response, ContractError> {
     // It will be tried to call the should_never_be_called function below.
     // But, should be blocked by VM host side normally because it's a reentrancy case.
-    reentrancy(env.contract.address);
+    let address = from_slice(&deps.storage.get(b"dynamic_callee_contract").unwrap())?;
+    let contract = CalleeContract { address };
+    contract.reentrancy(env.contract.address);
     Ok(Response::default())
 }
 

--- a/contracts/dynamic-caller-contract/src/msg.rs
+++ b/contracts/dynamic-caller-contract/src/msg.rs
@@ -13,3 +13,6 @@ pub enum ExecuteMsg {
     Ping { ping_num: Uint128 },
     TryReEntrancy {},
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct QueryMsg {}

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -9,28 +9,28 @@ fn required_imports() -> Vec<(String, String, FunctionType)> {
     vec![
         (
             String::from("stub_pong"),
-            String::from("dynamic_callee_contract"),
-            ([Type::I32], [Type::I32]).into(),
-        ),
-        (
-            String::from("stub_pong_with_struct"),
-            String::from("dynamic_callee_contract"),
-            ([Type::I32], [Type::I32]).into(),
-        ),
-        (
-            String::from("stub_pong_with_tuple"),
-            String::from("dynamic_callee_contract"),
-            ([Type::I32], [Type::I32]).into(),
-        ),
-        (
-            String::from("stub_pong_with_tuple_takes_2_args"),
-            String::from("dynamic_callee_contract"),
+            String::from("CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
+            String::from("stub_pong_with_struct"),
+            String::from("CalleeContract"),
+            ([Type::I32, Type::I32], [Type::I32]).into(),
+        ),
+        (
+            String::from("stub_pong_with_tuple"),
+            String::from("CalleeContract"),
+            ([Type::I32, Type::I32], [Type::I32]).into(),
+        ),
+        (
+            String::from("stub_pong_with_tuple_takes_2_args"),
+            String::from("CalleeContract"),
+            ([Type::I32, Type::I32, Type::I32], [Type::I32]).into(),
+        ),
+        (
             String::from("stub_pong_env"),
-            String::from("dynamic_callee_contract"),
-            ([], [Type::I32]).into(),
+            String::from("CalleeContract"),
+            ([Type::I32], [Type::I32]).into(),
         ),
     ]
 }

--- a/packages/derive/src/contract.rs
+++ b/packages/derive/src/contract.rs
@@ -1,0 +1,104 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::spanned::Spanned;
+use syn::{Attribute, DeriveInput, Error, Fields, Ident, Result};
+
+fn generate_get_address(address_field: &Ident) -> TokenStream {
+    quote! {
+        fn get_address(&self) -> cosmwasm_std::Addr {
+            self.#address_field.clone()
+        }
+    }
+}
+
+fn generate_set_address(address_field: &Ident) -> TokenStream {
+    quote! {
+        fn set_address(&mut self, address: cosmwasm_std::Addr) {
+            self.#address_field = address
+        }
+    }
+}
+
+fn generate_impl_contract(struct_id: &Ident, address_field: &Ident) -> TokenStream {
+    let get_fn = generate_get_address(address_field);
+    let set_fn = generate_set_address(address_field);
+    quote! {
+        impl Contract for #struct_id {
+            #get_fn
+            #set_fn
+        }
+    }
+}
+
+fn has_address_attribute(attrs: &[Attribute]) -> bool {
+    attrs.iter().filter(|a| a.path.is_ident("address")).count() > 0
+}
+
+/// scan fields and extraction a field specifying address.
+/// The priority is "contract_address" -> "contract_addr"
+/// -> "address" -> "addr"
+fn scan_address_field(fields: &Fields) -> Option<Ident> {
+    let candidates = vec!["contract_address", "contract_addr", "address", "addr"];
+    for field in fields {
+        match &field.ident {
+            Some(id) => {
+                for candidate in &candidates {
+                    if id == candidate {
+                        return Some(id.clone());
+                    }
+                }
+            }
+            None => continue,
+        }
+    }
+    None
+}
+
+fn find_address_field_id(fields: Fields) -> Result<Ident> {
+    let filtered = fields
+        .iter()
+        .filter(|field| has_address_attribute(&field.attrs));
+    match filtered.clone().count() {
+        0 => match scan_address_field(&fields) {
+            Some(id) => Ok(id),
+            None => Err(Error::new(
+                fields.span(),
+                "[Contract] There are no field specifying address.",
+            )),
+        },
+        1 => {
+            let field = filtered.last().unwrap().clone();
+            match field.ident {
+                Some(id) => Ok(id),
+                None => Err(Error::new(
+                    field.span(),
+                    "[Contract] The field attributed `address` has no name.",
+                )),
+            }
+        }
+        _ => Err(Error::new(
+            fields.span(),
+            "[Contract] Only one or zero fields can have `address` attribute.",
+        )),
+    }
+}
+
+/// derive `Contract` from a derive input. The input needs to be a struct.
+pub fn derive_contract(input: DeriveInput) -> TokenStream {
+    match input.data {
+        syn::Data::Struct(struct_data) => match find_address_field_id(struct_data.fields) {
+            Ok(address_field_id) => generate_impl_contract(&input.ident, &address_field_id),
+            Err(e) => e.to_compile_error(),
+        },
+        syn::Data::Enum(enum_data) => Error::new(
+            enum_data.enum_token.span,
+            "[Contract] `derive(Contract)` cannot be applied to Enum.",
+        )
+        .to_compile_error(),
+        syn::Data::Union(union_data) => Error::new(
+            union_data.union_token.span,
+            "[Contract] `derive(Contract)` cannot be applied to Union.",
+        )
+        .to_compile_error(),
+    }
+}

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -1,5 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
+use syn::{Ident, ItemTrait, Meta, NestedMeta, Signature, TraitItem, TypeParamBound};
 
 use crate::utils::{abort_by, collect_available_arg_types, has_return_value, make_typed_return};
 
@@ -9,98 +10,102 @@ macro_rules! abort_by_dynamic_link {
     };
 }
 
-pub fn parse_contract_name(nested_meta: &syn::NestedMeta) -> String {
-    let name_value = match nested_meta {
-        syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) => Some(name_value),
-        _ => abort_by_dynamic_link!(nested_meta, "contract_name must be a NameValue"),
-    };
-
-    match name_value {
-        Some(name_value) => {
-            if name_value.path.is_ident("contract_name") {
-                match &name_value.lit {
-                    syn::Lit::Str(literal) => literal.value(),
-                    _ => abort_by_dynamic_link!(
-                        name_value.lit,
-                        "contract_name value is not string literal"
-                    ),
-                }
-            } else {
-                abort_by_dynamic_link!(name_value.path, "only allowed the \"contract_name\"")
-            }
-        }
-        None => abort_by_dynamic_link!(nested_meta, "invalid attribute type"),
+pub fn parse_contract_struct_id(nested_meta: &syn::NestedMeta) -> Ident {
+    match nested_meta {
+        NestedMeta::Meta(Meta::Path(path)) => match path.get_ident() {
+            Some(id) => id.clone(),
+            None => abort_by_dynamic_link!(
+                nested_meta,
+                "contract struct id must be specified like `#[dynamic_link(CalleeContract)]`"
+            ),
+        },
+        _ => abort_by_dynamic_link!(
+            nested_meta,
+            "contract struct id must be specified like `#[dynamic_link(CalleeContract)]`"
+        ),
     }
 }
 
 pub fn generate_import_contract_declaration(
-    contract_name: String,
-    exist_extern_block: syn::ItemForeignMod,
+    contract_struct_id: &Ident,
+    trait_def: &ItemTrait,
 ) -> TokenStream {
-    //if not specified the ABI(None), the default value of extern ABI is C.
-    if let Some(ref extern_abi) = exist_extern_block.abi.name {
-        if extern_abi.value() != "C" {
-            abort_by_dynamic_link!(
-                extern_abi,
-                "ABI only supports the C. not recommended to specify the ABI yourself."
-            );
+    if !has_supertrait_contract(trait_def) {
+        abort_by_dynamic_link!(
+            trait_def,
+            "dynamic link trait must has `cosmwasm_std::Contract` as one of its supertraits."
+        )
+    }
+
+    let mut signatures: Vec<&Signature> = vec![];
+    for item in &trait_def.items {
+        match item {
+            TraitItem::Method(method) => signatures.push(&method.sig),
+            _ => abort_by_dynamic_link!(
+                item,
+                "other than method cannot be defined in dynamic link traits."
+            ),
         }
     }
 
-    let foreign_function_decls: Vec<&syn::ForeignItemFn> = exist_extern_block
-        .items
-        .iter()
-        .map(|foreign_item| match foreign_item {
-            syn::ForeignItem::Fn(item_fn) => item_fn,
-            _ => abort_by_dynamic_link!(foreign_item, "only function type is allowed."),
-        })
-        .collect();
+    let extern_block = generate_extern_block(contract_struct_id.to_string(), &signatures);
+    let implement_block = generate_implements(&trait_def.ident, contract_struct_id, &signatures);
 
-    let mut new_item = TokenStream::new();
-    new_item.extend(generate_extern_block(
-        contract_name,
-        &foreign_function_decls,
-    ));
-    for func_decl in foreign_function_decls {
-        new_item.extend(generate_serialization_func(func_decl));
+    quote! {
+        #extern_block
+
+        #trait_def
+
+        #implement_block
     }
-
-    new_item
 }
 
-fn generate_extern_block(
-    module_name: String,
-    origin_foreign_func_decls: &[&syn::ForeignItemFn],
-) -> TokenStream {
-    let redeclared_funcs = origin_foreign_func_decls.iter().map(|func_decl| {
-        let args_len = func_decl.sig.inputs.len();
-        let stub_func_name_ident = format_ident!("stub_{}", func_decl.sig.ident);
+fn has_supertrait_contract(trait_def: &ItemTrait) -> bool {
+    trait_def.supertraits.iter().any(|sb| match sb {
+        TypeParamBound::Trait(tb) => tb.path.segments.last().unwrap().ident == "Contract",
+        _ => false,
+    })
+}
+
+fn generate_extern_block(module_name: String, methods: &[&Signature]) -> TokenStream {
+    let stub_funcs = methods.iter().map(|signature| {
+        let args_len = signature.inputs.len() - 1;
+        let stub_func_name_ident = format_ident!("stub_{}", signature.ident);
         let renamed_param_defs: Vec<_> = (0..args_len)
             .map(|i| {
                 let renamed_param_ident = format_ident!("ptr{}", i);
                 quote! { #renamed_param_ident: u32 }
             })
             .collect();
-        let typed_return = make_typed_return(&func_decl.sig.output);
+        let typed_return = make_typed_return(&signature.output);
         quote! {
-            fn #stub_func_name_ident(#(#renamed_param_defs),*) #typed_return;
+            fn #stub_func_name_ident(addr: u32 #(, #renamed_param_defs)*) #typed_return;
         }
     });
 
     quote! {
         #[link(wasm_import_module = #module_name)]
         extern "C" {
-            #(#redeclared_funcs)*
+            #(#stub_funcs)*
+        }
+    }
+}
+
+fn generate_implements(trait_id: &Ident, struct_id: &Ident, methods: &[&Signature]) -> TokenStream {
+    let impl_funcs = methods.iter().map(|sig| generate_serialization_func(sig));
+    quote! {
+        impl #trait_id for #struct_id {
+            #(#impl_funcs)*
         }
     }
 }
 
 //Defines a function that was originally imported to execute serialization and call to imported stub_xxx.
-fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenStream {
-    let func_name = &origin_func_decl.sig.ident;
+fn generate_serialization_func(signature: &Signature) -> TokenStream {
+    let func_name = &signature.ident;
 
-    let args_len = origin_func_decl.sig.inputs.len();
-    let arg_types = collect_available_arg_types(&origin_func_decl.sig, "dynamic_link".to_string());
+    let args_len = signature.inputs.len() - 1;
+    let arg_types = collect_available_arg_types(signature, "dynamic_link".to_string());
 
     let renamed_param_defs: Vec<_> = (0..args_len)
         .map(|i| {
@@ -117,12 +122,14 @@ fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenSt
         .map(|i| format_ident!("region_arg{}", i))
         .collect();
 
-    let return_types = &origin_func_decl.sig.output;
+    let return_types = &signature.output;
     let call_stub_and_return =
-        make_call_stub_and_return(&func_name.to_string(), args_len, return_types);
+        make_call_stub_and_return(func_name, &region_arg_idents, return_types);
     quote! {
-        fn #func_name(#(#renamed_param_defs),*) #return_types {
+        fn #func_name(&self #(, #renamed_param_defs)*) #return_types {
+            let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
             #(let #vec_arg_idents = cosmwasm_std::to_vec(&#arg_idents).unwrap();)*
+            let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
             #(let #region_arg_idents = cosmwasm_std::memory::release_buffer(#vec_arg_idents) as u32;)*
             unsafe {
                 #call_stub_and_return
@@ -132,24 +139,20 @@ fn generate_serialization_func(origin_func_decl: &syn::ForeignItemFn) -> TokenSt
 }
 
 fn make_call_stub_and_return(
-    func_name: &str,
-    args_len: usize,
+    func_id: &Ident,
+    arg_idents: &[Ident],
     return_type: &syn::ReturnType,
 ) -> TokenStream {
-    let ident_func_name = format_ident!("stub_{}", func_name);
-    let arguments: Vec<_> = (0..args_len)
-        .map(|n| format_ident!("region_arg{}", n))
-        .collect();
-
+    let stub_func_id = format_ident!("stub_{}", func_id);
     if has_return_value(return_type) {
         quote! {
-            let result = #ident_func_name(#(#arguments),*);
+            let result = #stub_func_id(region_addr #(, #arg_idents)*);
             let vec_result = cosmwasm_std::memory::consume_region(result as *mut cosmwasm_std::memory::Region);
             cosmwasm_std::from_slice(&vec_result).unwrap()
         }
     } else {
         quote! {
-            #ident_func_name(#(#arguments),*);
+            #stub_func_id(region_addr #(, #arg_idents)*);
         }
     }
 }
@@ -157,65 +160,51 @@ fn make_call_stub_and_return(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use syn::{parse_quote, ItemFn};
+    use syn::{parse_quote, ItemTrait, Signature};
 
     #[test]
     fn make_call_stub_and_return_works() {
         {
-            let function_foo_ret0: ItemFn = parse_quote! {
-                fn foo() {
-                }
+            let sig_foo_ret0: Signature = parse_quote! {
+                fn foo()
             };
 
-            let result_code = make_call_stub_and_return(
-                &function_foo_ret0.sig.ident.to_string(),
-                0,
-                &function_foo_ret0.sig.output,
-            )
-            .to_string();
+            let result_code =
+                make_call_stub_and_return(&sig_foo_ret0.ident, &[], &sig_foo_ret0.output)
+                    .to_string();
 
             let expected: TokenStream = parse_quote! {
-                stub_foo();
+                stub_foo(region_addr);
             };
             assert_eq!(expected.to_string(), result_code);
         }
         {
-            let function_foo_ret1: ItemFn = parse_quote! {
-                fn foo() -> u64 {
-                    1
-                }
+            let sig_foo_ret1: Signature = parse_quote! {
+                fn foo() -> u64
             };
 
-            let result_code = make_call_stub_and_return(
-                &function_foo_ret1.sig.ident.to_string(),
-                0,
-                &function_foo_ret1.sig.output,
-            )
-            .to_string();
+            let result_code =
+                make_call_stub_and_return(&sig_foo_ret1.ident, &[], &sig_foo_ret1.output)
+                    .to_string();
 
             let expected: TokenStream = parse_quote! {
-                let result = stub_foo();
+                let result = stub_foo(region_addr);
                 let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
                 cosmwasm_std::from_slice(&vec_result).unwrap()
             };
             assert_eq!(expected.to_string(), result_code);
         }
         {
-            let function_foo_ret2: ItemFn = parse_quote! {
-                fn foo() -> (u64, u64) {
-                    (1, 2)
-                }
+            let sig_foo_ret2: Signature = parse_quote! {
+                fn foo() -> (u64, u64)
             };
 
-            let result_code = make_call_stub_and_return(
-                &function_foo_ret2.sig.ident.to_string(),
-                0,
-                &function_foo_ret2.sig.output,
-            )
-            .to_string();
+            let result_code =
+                make_call_stub_and_return(&sig_foo_ret2.ident, &[], &sig_foo_ret2.output)
+                    .to_string();
 
             let expected: TokenStream = parse_quote! {
-                let result = stub_foo();
+                let result = stub_foo(region_addr);
                 let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
                 cosmwasm_std::from_slice(&vec_result).unwrap()
             };
@@ -225,19 +214,19 @@ mod tests {
 
     #[test]
     fn generate_serialization_func_works() {
-        let test_extern: syn::ItemForeignMod = parse_quote! {
-            extern {
-                fn foo() -> u64;
-                fn bar(a: u64, b: String) -> u64;
-                fn foobar(a: u64, b: String) -> (u64, String);
+        let test_trait: ItemTrait = parse_quote! {
+            trait Callee: Contract {
+                fn foo(&self) -> u64;
+                fn bar(&self, a: u64, b: String) -> u64;
+                fn foobar(&self, a: u64, b: String) -> (u64, String);
             }
         };
 
-        let foreign_function_decls: Vec<&syn::ForeignItemFn> = test_extern
+        let method_sigs: Vec<&Signature> = test_trait
             .items
             .iter()
-            .map(|foreign_item| match foreign_item {
-                syn::ForeignItem::Fn(item_fn) => item_fn,
+            .map(|item| match item {
+                syn::TraitItem::Method(method) => &method.sig,
                 _ => {
                     panic!()
                 }
@@ -245,11 +234,13 @@ mod tests {
             .collect();
 
         {
-            let result_code = generate_serialization_func(foreign_function_decls[0]).to_string();
+            let result_code = generate_serialization_func(method_sigs[0]).to_string();
             let expected: TokenStream = parse_quote! {
-                fn foo () -> u64 {
+                fn foo (&self) -> u64 {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
                     unsafe {
-                        let result = stub_foo();
+                        let result = stub_foo(region_addr);
                         let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
                         cosmwasm_std::from_slice(&vec_result).unwrap()
                     }
@@ -258,15 +249,17 @@ mod tests {
             assert_eq!(expected.to_string(), result_code);
         }
         {
-            let result_code = generate_serialization_func(foreign_function_decls[1]).to_string();
+            let result_code = generate_serialization_func(method_sigs[1]).to_string();
             let expected: TokenStream = parse_quote! {
-                fn bar (arg0 : u64 , arg1 : String) -> u64 {
+                fn bar (&self, arg0: u64 , arg1: String) -> u64 {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
                     let vec_arg0 = cosmwasm_std::to_vec(&arg0).unwrap();
                     let vec_arg1 = cosmwasm_std::to_vec(&arg1).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
                     let region_arg0 = cosmwasm_std::memory::release_buffer(vec_arg0) as u32;
                     let region_arg1 = cosmwasm_std::memory::release_buffer(vec_arg1) as u32;
                     unsafe {
-                        let result = stub_bar(region_arg0, region_arg1);
+                        let result = stub_bar(region_addr, region_arg0, region_arg1);
                         let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
                         cosmwasm_std::from_slice(&vec_result).unwrap()
                     }
@@ -275,15 +268,17 @@ mod tests {
             assert_eq!(expected.to_string(), result_code);
         }
         {
-            let result_code = generate_serialization_func(foreign_function_decls[2]).to_string();
+            let result_code = generate_serialization_func(method_sigs[2]).to_string();
             let expected: TokenStream = parse_quote! {
-                fn foobar(arg0: u64, arg1: String) -> (u64, String) {
+                fn foobar(&self, arg0: u64, arg1: String) -> (u64, String) {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
                     let vec_arg0 = cosmwasm_std::to_vec(&arg0).unwrap();
                     let vec_arg1 = cosmwasm_std::to_vec(&arg1).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
                     let region_arg0 = cosmwasm_std::memory::release_buffer(vec_arg0) as u32;
                     let region_arg1 = cosmwasm_std::memory::release_buffer(vec_arg1) as u32;
                     unsafe {
-                        let result = stub_foobar(region_arg0, region_arg1);
+                        let result = stub_foobar(region_addr, region_arg0, region_arg1);
                         let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
                         cosmwasm_std::from_slice(&vec_result).unwrap()
                     }
@@ -295,19 +290,19 @@ mod tests {
 
     #[test]
     fn generate_extern_block_works() {
-        let test_extern: syn::ItemForeignMod = parse_quote! {
-            extern {
-                fn foo(a: u64, b: String) -> u64;
-                fn bar();
-                fn foobar(a: u64, b: String) -> (u64, String);
+        let test_trait: ItemTrait = parse_quote! {
+            trait Callee: Contract {
+                fn foo(&self, a: u64, b: String) -> u64;
+                fn bar(&self);
+                fn foobar(&self, a: u64, b: String) -> (u64, String);
             }
         };
 
-        let foreign_function_decls: Vec<&syn::ForeignItemFn> = test_extern
+        let method_sigs: Vec<&Signature> = test_trait
             .items
             .iter()
-            .map(|foreign_item| match foreign_item {
-                syn::ForeignItem::Fn(item_fn) => item_fn,
+            .map(|item| match item {
+                syn::TraitItem::Method(method) => &method.sig,
                 _ => {
                     panic!()
                 }
@@ -315,13 +310,82 @@ mod tests {
             .collect();
 
         let result_code =
-            generate_extern_block("test_contract".to_string(), &foreign_function_decls).to_string();
+            generate_extern_block("test_contract".to_string(), &method_sigs).to_string();
         let expected: TokenStream = parse_quote! {
             #[link(wasm_import_module = "test_contract")]
             extern "C" {
-                fn stub_foo(ptr0: u32, ptr1: u32) -> u32;
-                fn stub_bar();
-                fn stub_foobar(ptr0: u32, ptr1: u32) -> u32;
+                fn stub_foo(addr: u32, ptr0: u32, ptr1: u32) -> u32;
+                fn stub_bar(addr: u32);
+                fn stub_foobar(addr: u32, ptr0: u32, ptr1: u32) -> u32;
+            }
+        };
+        assert_eq!(expected.to_string(), result_code);
+    }
+
+    #[test]
+    fn generate_implements_works() {
+        let test_trait: ItemTrait = parse_quote! {
+            trait Callee: Contract {
+                fn foo(&self, a: u64, b: String) -> u64;
+                fn bar(&self);
+                fn foobar(&self, a: u64, b: String) -> (u64, String);
+            }
+        };
+
+        let method_sigs: Vec<&Signature> = test_trait
+            .items
+            .iter()
+            .map(|item| match item {
+                syn::TraitItem::Method(method) => &method.sig,
+                _ => {
+                    panic!()
+                }
+            })
+            .collect();
+
+        let result_code = generate_implements(
+            &test_trait.ident,
+            &format_ident!("CalleeContract"),
+            &method_sigs,
+        )
+        .to_string();
+        let expected: TokenStream = parse_quote! {
+            impl Callee for CalleeContract {
+                fn foo(&self, arg0: u64, arg1: String) -> u64 {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
+                    let vec_arg0 = cosmwasm_std::to_vec(&arg0).unwrap();
+                    let vec_arg1 = cosmwasm_std::to_vec(&arg1).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
+                    let region_arg0 = cosmwasm_std::memory::release_buffer(vec_arg0) as u32;
+                    let region_arg1 = cosmwasm_std::memory::release_buffer(vec_arg1) as u32;
+                    unsafe {
+                        let result = stub_foo(region_addr, region_arg0, region_arg1);
+                        let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
+                        cosmwasm_std::from_slice(&vec_result).unwrap()
+                    }
+                }
+
+                fn bar(&self) {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
+                    unsafe {
+                        stub_bar(region_addr);
+                    }
+                }
+
+                fn foobar(&self, arg0: u64, arg1: String) -> (u64, String) {
+                    let vec_addr = cosmwasm_std::to_vec(&self.get_address()).unwrap();
+                    let vec_arg0 = cosmwasm_std::to_vec(&arg0).unwrap();
+                    let vec_arg1 = cosmwasm_std::to_vec(&arg1).unwrap();
+                    let region_addr = cosmwasm_std::memory::release_buffer(vec_addr) as u32;
+                    let region_arg0 = cosmwasm_std::memory::release_buffer(vec_arg0) as u32;
+                    let region_arg1 = cosmwasm_std::memory::release_buffer(vec_arg1) as u32;
+                    unsafe {
+                        let result = stub_foobar(region_addr, region_arg0, region_arg1);
+                        let vec_result = cosmwasm_std::memory::consume_region(result as * mut cosmwasm_std::memory::Region);
+                        cosmwasm_std::from_slice(&vec_result).unwrap()
+                    }
+                }
             }
         };
         assert_eq!(expected.to_string(), result_code);

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -7,6 +7,7 @@ use quote::quote;
 use std::str::FromStr;
 
 mod callable_point;
+mod contract;
 mod dynamic_link;
 mod utils;
 /// This attribute macro generates the boilerplate required to call into the
@@ -120,4 +121,18 @@ pub fn dynamic_link(attr: TokenStream, item: TokenStream) -> TokenStream {
         contract_name,
         exist_extern_block,
     ))
+}
+
+/// This derive macro is for implementing `cosmwasm_std::Contract`
+///
+/// This implements `get_address` and `set_address` for address field.
+/// Address field is selected as following
+/// 1. If there is a field attributed with `#[address]`, the field will
+///    be used as the address field.
+/// 2. Choose a field by field name. The priority of the name is
+///    "contract_address" -> "contract_addr" -> "address" -> "addr".
+#[proc_macro_derive(Contract, attributes(address))]
+pub fn derive_contract(input: TokenStream) -> TokenStream {
+    let derive_input = parse_macro_input!(input as syn::DeriveInput);
+    contract::derive_contract(derive_input).into()
 }

--- a/packages/derive/tests/test.rs
+++ b/packages/derive/tests/test.rs
@@ -1,0 +1,37 @@
+extern crate cosmwasm_derive;
+
+use cosmwasm_std::{Addr, Contract};
+
+#[test]
+fn basic() {
+    #[derive(Contract)]
+    struct Callee {
+        address: Addr,
+    }
+
+    let mut callee = Callee {
+        address: Addr::unchecked("foo"),
+    };
+    assert_eq!(callee.get_address(), Addr::unchecked("foo"));
+    callee.set_address(Addr::unchecked("bar"));
+    assert_eq!(callee.get_address(), Addr::unchecked("bar"));
+}
+
+#[test]
+#[allow(dead_code)]
+fn specify_field() {
+    #[derive(Contract)]
+    struct Callee {
+        address: Addr,
+        #[address]
+        address_actually: Addr,
+    }
+
+    let mut callee = Callee {
+        address: Addr::unchecked("dummy"),
+        address_actually: Addr::unchecked("foo"),
+    };
+    assert_eq!(callee.get_address(), Addr::unchecked("foo"));
+    callee.set_address(Addr::unchecked("bar"));
+    assert_eq!(callee.get_address(), Addr::unchecked("bar"));
+}

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -63,7 +63,7 @@ pub use crate::results::{DistributionMsg, StakingMsg};
 pub use crate::serde::{from_binary, from_slice, to_binary, to_vec};
 pub use crate::storage::MemoryStorage;
 pub use crate::timestamp::Timestamp;
-pub use crate::traits::{Api, Querier, QuerierResult, QuerierWrapper, Storage};
+pub use crate::traits::{Api, Contract, Querier, QuerierResult, QuerierWrapper, Storage};
 pub use crate::types::{BlockInfo, ContractInfo, Env, MessageInfo};
 pub use crate::uuid::{new_uuid, Uuid};
 

--- a/packages/std/src/lib.rs
+++ b/packages/std/src/lib.rs
@@ -116,3 +116,4 @@ pub mod testing {
 pub use cosmwasm_derive::callable_point;
 pub use cosmwasm_derive::dynamic_link;
 pub use cosmwasm_derive::entry_point;
+pub use cosmwasm_derive::Contract;

--- a/packages/std/src/traits.rs
+++ b/packages/std/src/traits.rs
@@ -136,6 +136,15 @@ pub trait Querier {
     fn raw_query(&self, bin_request: &[u8]) -> QuerierResult;
 }
 
+/// Contract represents a dynamic linked callee contract.
+pub trait Contract {
+    /// get contract address
+    fn get_address(&self) -> Addr;
+
+    /// set contract address
+    fn set_address(&mut self, address: Addr);
+}
+
 #[derive(Copy, Clone)]
 pub struct QuerierWrapper<'a>(&'a dyn Querier);
 

--- a/packages/vm/src/dynamic_link.rs
+++ b/packages/vm/src/dynamic_link.rs
@@ -304,7 +304,6 @@ mod tests {
                 (export "instantiate" (func 0))
                 (export "allocate" (func 0))
                 (export "deallocate" (func 0))
-            
                 (type (func))
                 (func (type 0) nop)
                 (export "foo" (func 0))


### PR DESCRIPTION
# Description
This PR changes how to specify the callee contract address in the caller contract.
For this purpose, it contains

- Define the `Contract` trait that represents the callee contract
- Implement a derive macro for `Contract`
- Modify the VM code to change from where the contract address is fetched
- Modify the `dynamic_link` macro

What is changed about the usage of the `#[dynamic_link]` macro is described in #207.

Closes #207

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
