### PR TITLE
perf: Add benchmarks for estimate dynamic link gas cost

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -41,7 +41,7 @@ jobs:
         run: rustc --version; cargo --version; rustup --version; rustup target list --installed
       - name: Run vm benchmarks (Singlepass)
         working-directory: ${{env.working-directory}}/vm
-        run: cargo bench --no-default-features -- --color never --save-baseline singlepass
+        run: cargo bench --no-default-features --features bench -- --color never --save-baseline singlepass
       - name: Run crypto benchmarks
         working-directory: ${{env.working-directory}}/crypto
         run: cargo bench -- --color never --save-baseline crypto

--- a/packages/vm/Cargo.toml
+++ b/packages/vm/Cargo.toml
@@ -24,6 +24,8 @@ staking = ["cosmwasm-std/staking"]
 stargate = ["cosmwasm-std/stargate"]
 # Use cranelift backend instead of singlepass. This is required for development on Windows.
 cranelift = ["wasmer/cranelift"]
+# for benchmark
+bench = []
 
 [lib]
 # See https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
@@ -65,3 +67,4 @@ clap = "2.33.3"
 [[bench]]
 name = "main"
 harness = false
+required-features = ["bench"]

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -2,14 +2,19 @@ use criterion::{criterion_group, criterion_main, Criterion, PlottingBackend};
 use std::time::Duration;
 use tempfile::TempDir;
 
-use cosmwasm_std::{coins, Empty};
+use cosmwasm_std::{coins, to_vec, Addr, Empty};
 use cosmwasm_vm::testing::{
-    mock_backend, mock_env, mock_info, mock_instance_options, MockApi, MockQuerier, MockStorage,
+    mock_backend, mock_env, mock_info, mock_instance, mock_instance_options,
+    mock_instance_with_options, write_data_to_mock_env, MockApi, MockInstanceOptions, MockQuerier,
+    MockStorage, INSTANCE_CACHE,
 };
 use cosmwasm_vm::{
-    call_execute, call_instantiate, features_from_csv, Cache, CacheOptions, Checksum, Instance,
-    InstanceOptions, Size,
+    call_execute, call_instantiate, features_from_csv, native_dynamic_link_trampoline_for_bench,
+    Backend, BackendApi, BackendError, BackendResult, Cache, CacheOptions, Checksum, Environment,
+    FunctionMetadata, GasInfo, Instance, InstanceOptions, Querier, Size, Storage, WasmerVal,
 };
+use std::cell::RefCell;
+use wasmer_types::Type;
 
 // Instance
 const DEFAULT_MEMORY_LIMIT: Size = Size::mebi(64);
@@ -18,10 +23,50 @@ const DEFAULT_INSTANCE_OPTIONS: InstanceOptions = InstanceOptions {
     gas_limit: DEFAULT_GAS_LIMIT,
     print_debug: false,
 };
+
 // Cache
 const MEMORY_CACHE_SIZE: Size = Size::mebi(200);
 
 static CONTRACT: &[u8] = include_bytes!("../testdata/hackatom.wasm");
+
+// For Dynamic Call
+const CALLEE_NAME_ADDR: &str = "callee";
+const CALLER_NAME_ADDR: &str = "caller";
+
+// DummyApi is Api with dummy `call_contract` which does nothing
+#[derive(Copy, Clone)]
+struct DummyApi {}
+
+impl BackendApi for DummyApi {
+    fn canonical_address(&self, _human: &str) -> BackendResult<Vec<u8>> {
+        (
+            Err(BackendError::unknown("not implemented")),
+            GasInfo::with_cost(0),
+        )
+    }
+
+    fn human_address(&self, _canonical: &[u8]) -> BackendResult<String> {
+        (
+            Err(BackendError::unknown("not implemented")),
+            GasInfo::with_cost(0),
+        )
+    }
+
+    fn contract_call<A, S, Q>(
+        &self,
+        _caller_env: &Environment<A, S, Q>,
+        _contract_addr: &str,
+        _func_info: &FunctionMetadata,
+        _args: &[WasmerVal],
+    ) -> BackendResult<Box<[WasmerVal]>>
+    where
+        A: BackendApi + 'static,
+        S: Storage + 'static,
+        Q: Querier + 'static,
+    {
+        (Ok(Box::from([])), GasInfo::with_cost(0))
+    }
+}
 
 fn bench_instance(c: &mut Criterion) {
     let mut group = c.benchmark_group("Instance");
@@ -187,6 +232,129 @@ fn bench_cache(c: &mut Criterion) {
     group.finish();
 }
 
+fn prepare_dynamic_call_data<A: BackendApi>(
+    callee_address: Addr,
+    func_info: FunctionMetadata,
+    caller_env: &mut Environment<A, MockStorage, MockQuerier>,
+) -> u32 {
+    let data = to_vec(&callee_address).unwrap();
+    let region_ptr = write_data_to_mock_env(caller_env, &data).unwrap();
+
+    caller_env.set_callee_function_metadata(Some(func_info));
+
+    let serialized_env = to_vec(&mock_env()).unwrap();
+    caller_env.set_serialized_env(&serialized_env);
+
+    let storage = MockStorage::new();
+    let querier: MockQuerier<Empty> = MockQuerier::new(&[]);
+    caller_env.move_in(storage, querier);
+    region_ptr
+}
+
+fn bench_dynamic_link(c: &mut Criterion) {
+    let mut group = c.benchmark_group("DynamicLink");
+
+    group.bench_function(
+        "native_dynamic_link_trampoline with dummy contract_call",
+        |b| {
+            let backend = Backend {
+                api: DummyApi {},
+                storage: MockStorage::default(),
+                querier: MockQuerier::new(&[]),
+            };
+            let mock_options = MockInstanceOptions::default();
+            let options = InstanceOptions {
+                gas_limit: mock_options.gas_limit,
+                print_debug: mock_options.print_debug,
+            };
+            let instance =
+                Instance::from_code(CONTRACT, backend, options, mock_options.memory_limit).unwrap();
+            let mut dummy_env = instance.env;
+            let callee_address = Addr::unchecked(CALLEE_NAME_ADDR);
+            let target_func_info = FunctionMetadata {
+                module_name: CALLEE_NAME_ADDR.to_string(),
+                name: "foo".to_string(),
+                signature: ([Type::I32], []).into(),
+            };
+
+            let address_region =
+                prepare_dynamic_call_data(callee_address, target_func_info, &mut dummy_env);
+
+            b.iter(|| {
+                let _ = native_dynamic_link_trampoline_for_bench(
+                    &dummy_env,
+                    &[WasmerVal::I32(address_region as i32)],
+                )
+                .unwrap();
+            })
+        },
+    );
+
+    group.bench_function(
+        "native_dynamic_link_trampoline with mock cache environment",
+        |b| {
+            let callee_wasm = wat::parse_str(
+                r#"(module
+                (memory 3)
+                (export "memory" (memory 0))
+                (export "interface_version_5" (func 0))
+                (export "instantiate" (func 0))
+                (export "allocate" (func 0))
+                (export "deallocate" (func 0))
+                (type (func))
+                (func (type 0) nop)
+                (export "foo" (func 0))
+            )"#,
+            )
+            .unwrap();
+
+            INSTANCE_CACHE.with(|lock| {
+                let mut cache = lock.write().unwrap();
+                cache.insert(
+                    CALLEE_NAME_ADDR.to_string(),
+                    RefCell::new(mock_instance(&callee_wasm, &[])),
+                );
+                cache.insert(
+                    CALLER_NAME_ADDR.to_string(),
+                    RefCell::new(mock_instance_with_options(
+                        &CONTRACT,
+                        MockInstanceOptions {
+                            gas_limit: 500_000_000_000,
+                            ..MockInstanceOptions::default()
+                        },
+                    )),
+                );
+            });
+
+            INSTANCE_CACHE.with(|lock| {
+                let cache = lock.read().unwrap();
+                let caller_instance = cache.get(CALLER_NAME_ADDR).unwrap();
+                let mut caller_env = &mut caller_instance.borrow_mut().env;
+                let target_func_info = FunctionMetadata {
+                    module_name: CALLER_NAME_ADDR.to_string(),
+                    name: "foo".to_string(),
+                    signature: ([Type::I32], []).into(),
+                };
+                let address_region = prepare_dynamic_call_data(
+                    Addr::unchecked(CALLEE_NAME_ADDR),
+                    target_func_info,
+                    &mut caller_env,
+                );
+
+                b.iter(|| {
+                    let _ = native_dynamic_link_trampoline_for_bench(
+                        &caller_env,
+                        &[WasmerVal::I32(address_region as i32)],
+                    )
+                    .unwrap();
+                })
+            });
+        },
+    );
+
+    group.finish()
+}
+
 fn make_config() -> Criterion {
     Criterion::default()
         .plotting_backend(PlottingBackend::Plotters)
@@ -205,4 +373,9 @@ criterion_group!(
     config = make_config();
     targets = bench_cache
 );
-criterion_main!(instance, cache);
+criterion_group!(
+    name = dynamic_link;
+    config = make_config();
+    targets = bench_dynamic_link
+);
+criterion_main!(instance, cache, dynamic_link);

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -320,7 +320,8 @@ fn bench_dynamic_link(c: &mut Criterion) {
                     RefCell::new(mock_instance_with_options(
                         &CONTRACT,
                         MockInstanceOptions {
-                            gas_limit: 500_000_000_000,
+                            // enough gas for bench iterations
+                            gas_limit: 500_000_000_000_000_000,
                             ..MockInstanceOptions::default()
                         },
                     )),

--- a/packages/vm/benches/main.rs
+++ b/packages/vm/benches/main.rs
@@ -425,5 +425,4 @@ criterion_group!(
     config = make_config();
     targets = bench_copy_region
 );
-//criterion_main!(instance, cache, dynamic_link, copy_region);
-criterion_main!(copy_region);
+criterion_main!(instance, cache, dynamic_link, copy_region);

--- a/packages/vm/src/dynamic_link.rs
+++ b/packages/vm/src/dynamic_link.rs
@@ -107,6 +107,19 @@ where
     })
 }
 
+#[cfg(feature = "bench")]
+pub fn native_dynamic_link_trampoline_for_bench<A: BackendApi, S: Storage, Q: Querier>(
+    env: &Environment<A, S, Q>,
+    args: &[WasmerVal],
+) -> Result<Vec<WasmerVal>, RuntimeError>
+where
+    A: BackendApi + 'static,
+    S: Storage + 'static,
+    Q: Querier + 'static,
+{
+    native_dynamic_link_trampoline(env, args)
+}
+
 pub fn dynamic_link<A: BackendApi, S: Storage, Q: Querier>(
     module: &Module,
     env: &Environment<A, S, Q>,

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -36,6 +36,8 @@ pub use crate::calls::{
 };
 pub use crate::checksum::Checksum;
 
+#[cfg(feature = "bench")]
+pub use crate::dynamic_link::native_dynamic_link_trampoline_for_bench;
 pub use crate::dynamic_link::{
     copy_region_vals_between_env, dynamic_link, FunctionMetadata, WasmerVal,
 };

--- a/packages/vm/src/lib.rs
+++ b/packages/vm/src/lib.rs
@@ -35,7 +35,8 @@ pub use crate::calls::{
     call_sudo_raw,
 };
 pub use crate::checksum::Checksum;
-
+#[cfg(feature = "bench")]
+pub use crate::conversion::{ref_to_u32, to_u32};
 #[cfg(feature = "bench")]
 pub use crate::dynamic_link::native_dynamic_link_trampoline_for_bench;
 pub use crate::dynamic_link::{
@@ -55,6 +56,8 @@ pub use crate::ibc_calls::{
     call_ibc_packet_receive_raw, call_ibc_packet_timeout, call_ibc_packet_timeout_raw,
 };
 pub use crate::instance::{GasReport, Instance, InstanceOptions};
+#[cfg(feature = "bench")]
+pub use crate::memory::{read_region, write_region};
 pub use crate::serde::{from_slice, to_vec};
 pub use crate::size::Size;
 

--- a/packages/vm/src/testing/environment.rs
+++ b/packages/vm/src/testing/environment.rs
@@ -1,22 +1,23 @@
-use super::{MockApi, MockQuerier, MockStorage};
+use super::{MockQuerier, MockStorage};
 use crate::conversion::ref_to_u32;
 use crate::memory::{read_region, write_region};
+use crate::BackendApi;
 use crate::Environment;
 use crate::VmResult;
 use crate::WasmerVal;
 
-pub fn write_data_to_mock_env(
-    env: &Environment<MockApi, MockStorage, MockQuerier>,
+pub fn write_data_to_mock_env<A: BackendApi>(
+    env: &Environment<A, MockStorage, MockQuerier>,
     data: &[u8],
-) -> VmResult<u32> {
+) -> VmResult<u32> where {
     let result = env.call_function1("allocate", &[(data.len() as u32).into()])?;
     let region_ptr = ref_to_u32(&result)?;
     write_region(&env.memory(), region_ptr, data)?;
     Ok(region_ptr)
 }
 
-pub fn read_data_from_mock_env(
-    env: &Environment<MockApi, MockStorage, MockQuerier>,
+pub fn read_data_from_mock_env<A: BackendApi>(
+    env: &Environment<A, MockStorage, MockQuerier>,
     wasm_ptr: &WasmerVal,
     size: usize,
 ) -> VmResult<Vec<u8>> {

--- a/packages/vm/src/testing/mock.rs
+++ b/packages/vm/src/testing/mock.rs
@@ -165,6 +165,7 @@ impl BackendApi for MockApi {
         };
         (result, gas_info)
     }
+
     fn contract_call<A, S, Q>(
         &self,
         caller_env: &Environment<A, S, Q>,


### PR DESCRIPTION
# Description
Add some benchmarks to estimate dynamic link gas cost.

- benchmarking `native_dynamic_link_trampoline`: used to estimate the gas cost to call for a dynamic linked function. calling a dynamic linked function takes this time and time to execute `contract_call`.
- benchmarking `read/write_region`: used to estimate the gas cost for copy values between two contract instances. This copy is executed in `contract_call`.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (NOT NEEDED)
- [ ] I have added tests to cover my changes. (NOT NEEDED)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
