### PR TITLE
fix: rename generated functions from dynamic_link and callable_point macro

### DIFF
--- a/contracts/call-number/tests/integration.rs
+++ b/contracts/call-number/tests/integration.rs
@@ -8,22 +8,22 @@ static CONTRACT_CALLER: &[u8] =
 fn required_imports() -> Vec<(String, String, FunctionType)> {
     vec![
         (
-            String::from("stub_add"),
+            String::from("add"),
             String::from("NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
-            String::from("stub_sub"),
+            String::from("sub"),
             String::from("NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
-            String::from("stub_mul"),
+            String::from("mul"),
             String::from("NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
-            String::from("stub_number"),
+            String::from("number"),
             String::from("NumberContract"),
             ([Type::I32], [Type::I32]).into(),
         ),

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -13,20 +13,20 @@ static CONTRACT_CALLEE: &[u8] =
 
 fn required_exports() -> Vec<(String, FunctionType)> {
     vec![
-        (String::from("stub_pong"), ([Type::I32], [Type::I32]).into()),
+        (String::from("pong"), ([Type::I32], [Type::I32]).into()),
         (
-            String::from("stub_pong_with_struct"),
+            String::from("pong_with_struct"),
             ([Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_with_tuple"),
+            String::from("pong_with_tuple"),
             ([Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_with_tuple_takes_2_args"),
+            String::from("pong_with_tuple_takes_2_args"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
-        (String::from("stub_pong_env"), ([], [Type::I32]).into()),
+        (String::from("pong_env"), ([], [Type::I32]).into()),
     ]
 }
 
@@ -77,11 +77,11 @@ fn callable_point_pong_works() {
 
     let required_exports = required_exports();
     let export_index = 0;
-    assert_eq!("stub_pong".to_string(), required_exports[export_index].0);
+    assert_eq!("pong".to_string(), required_exports[export_index].0);
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_pong",
+            "pong",
             &[param_region_ptr.into()],
         )
         .unwrap();
@@ -107,13 +107,13 @@ fn callable_point_pong_with_struct_works() {
     let required_exports = required_exports();
     let export_index = 1;
     assert_eq!(
-        "stub_pong_with_struct".to_string(),
+        "pong_with_struct".to_string(),
         required_exports[export_index].0
     );
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_pong_with_struct",
+            "pong_with_struct",
             &[param_region_ptr.into()],
         )
         .unwrap();
@@ -136,13 +136,13 @@ fn callable_point_pong_with_tuple_works() {
     let required_exports = required_exports();
     let export_index = 2;
     assert_eq!(
-        "stub_pong_with_tuple".to_string(),
+        "pong_with_tuple".to_string(),
         required_exports[export_index].0
     );
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_pong_with_tuple",
+            "pong_with_tuple",
             &[param_region_ptr.into()],
         )
         .unwrap();
@@ -168,13 +168,13 @@ fn callable_point_pong_with_tuple_takes_2_args_works() {
     let required_exports = required_exports();
     let export_index = 3;
     assert_eq!(
-        "stub_pong_with_tuple_takes_2_args".to_string(),
+        "pong_with_tuple_takes_2_args".to_string(),
         required_exports[export_index].0
     );
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_pong_with_tuple_takes_2_args",
+            "pong_with_tuple_takes_2_args",
             &[param_region_ptr1.into(), param_region_ptr2.into()],
         )
         .unwrap();
@@ -197,11 +197,11 @@ fn callable_point_pong_env_works() {
         .set_serialized_env(&to_vec(&mock_env()).unwrap());
     let export_index = 4;
     assert_eq!(
-        "stub_pong_env".to_string(),
+        "pong_env".to_string(),
         required_exports[export_index].0
     );
     let call_result = instance
-        .call_function_strict(&required_exports[export_index].1, "stub_pong_env", &[])
+        .call_function_strict(&required_exports[export_index].1, "pong_env", &[])
         .unwrap();
     assert_eq!(call_result.len(), 1);
 

--- a/contracts/dynamic-callee-contract/tests/integration.rs
+++ b/contracts/dynamic-callee-contract/tests/integration.rs
@@ -196,10 +196,7 @@ fn callable_point_pong_env_works() {
         .env
         .set_serialized_env(&to_vec(&mock_env()).unwrap());
     let export_index = 4;
-    assert_eq!(
-        "pong_env".to_string(),
-        required_exports[export_index].0
-    );
+    assert_eq!("pong_env".to_string(), required_exports[export_index].0);
     let call_result = instance
         .call_function_strict(&required_exports[export_index].1, "pong_env", &[])
         .unwrap();

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -8,27 +8,27 @@ static CONTRACT_CALLER: &[u8] =
 fn required_imports() -> Vec<(String, String, FunctionType)> {
     vec![
         (
-            String::from("stub_pong"),
+            String::from("pong"),
             String::from("CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_with_struct"),
+            String::from("pong_with_struct"),
             String::from("CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_with_tuple"),
+            String::from("pong_with_tuple"),
             String::from("CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_with_tuple_takes_2_args"),
+            String::from("pong_with_tuple_takes_2_args"),
             String::from("CalleeContract"),
             ([Type::I32, Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
-            String::from("stub_pong_env"),
+            String::from("pong_env"),
             String::from("CalleeContract"),
             ([Type::I32], [Type::I32]).into(),
         ),

--- a/contracts/number/tests/integration.rs
+++ b/contracts/number/tests/integration.rs
@@ -11,10 +11,10 @@ static CONTRACT: &[u8] = include_bytes!("../target/wasm32-unknown-unknown/releas
 
 fn required_exports() -> Vec<(String, FunctionType)> {
     vec![
-        (String::from("stub_add"), ([Type::I32], []).into()),
-        (String::from("stub_sub"), ([Type::I32], []).into()),
-        (String::from("stub_mul"), ([Type::I32], []).into()),
-        (String::from("stub_number"), ([], [Type::I32]).into()),
+        (String::from("add"), ([Type::I32], []).into()),
+        (String::from("sub"), ([Type::I32], []).into()),
+        (String::from("mul"), ([Type::I32], []).into()),
+        (String::from("number"), ([], [Type::I32]).into()),
     ]
 }
 
@@ -65,14 +65,14 @@ fn callable_point_add_works() {
 
     let required_exports = required_exports();
     let export_index = 0;
-    assert_eq!("stub_add".to_string(), required_exports[export_index].0);
+    assert_eq!("add".to_string(), required_exports[export_index].0);
 
     // Before solving #213, it issues an error.
-    // This is because `stub_add` panics without number in deps.storage.
+    // This is because `add` panics without number in deps.storage.
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_add",
+            "add",
             &[param_region_ptr.into()],
         )
         .unwrap_err();
@@ -88,14 +88,14 @@ fn callable_point_sub_works() {
 
     let required_exports = required_exports();
     let export_index = 1;
-    assert_eq!("stub_sub".to_string(), required_exports[export_index].0);
+    assert_eq!("sub".to_string(), required_exports[export_index].0);
 
     // Before solving #213, it issues an error.
-    // This is because `stub_sub` panics without number in deps.storage.
+    // This is because `sub` panics without number in deps.storage.
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_sub",
+            "sub",
             &[param_region_ptr.into()],
         )
         .unwrap_err();
@@ -111,14 +111,14 @@ fn callable_point_mul_works() {
 
     let required_exports = required_exports();
     let export_index = 2;
-    assert_eq!("stub_mul".to_string(), required_exports[export_index].0);
+    assert_eq!("mul".to_string(), required_exports[export_index].0);
 
     // Before solving #213, it issues an error.
-    // This is because `stub_add` panics without number in deps.storage.
+    // This is because `mul` panics without number in deps.storage.
     let call_result = instance
         .call_function_strict(
             &required_exports[export_index].1,
-            "stub_mul",
+            "mul",
             &[param_region_ptr.into()],
         )
         .unwrap_err();
@@ -131,11 +131,11 @@ fn callable_point_number_works() {
 
     let required_exports = required_exports();
     let export_index = 3;
-    assert_eq!("stub_number".to_string(), required_exports[export_index].0);
+    assert_eq!("number".to_string(), required_exports[export_index].0);
     // Before solving #213, it issues an error.
-    // This is because `stub_number` panics without number in deps.storage.
+    // This is because `number` panics without number in deps.storage.
     let call_result = instance
-        .call_function_strict(&required_exports[0].1, "stub_number", &[])
+        .call_function_strict(&required_exports[0].1, "number", &[])
         .unwrap_err();
     assert!(call_result.to_string().contains("RuntimeError: unreachable"))
 }

--- a/contracts/number/tests/integration.rs
+++ b/contracts/number/tests/integration.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::to_vec;
 use cosmwasm_vm::testing::{
-    mock_backend, mock_env, write_data_to_mock_env, Contract, MockApi,
-    MockInstanceOptions, MockQuerier, MockStorage,
+    mock_backend, mock_env, write_data_to_mock_env, Contract, MockApi, MockInstanceOptions,
+    MockQuerier, MockStorage,
 };
 use cosmwasm_vm::Instance;
 use std::collections::HashMap;
@@ -76,7 +76,9 @@ fn callable_point_add_works() {
             &[param_region_ptr.into()],
         )
         .unwrap_err();
-    assert!(call_result.to_string().contains("RuntimeError: unreachable"))
+    assert!(call_result
+        .to_string()
+        .contains("RuntimeError: unreachable"))
 }
 
 #[test]
@@ -99,7 +101,9 @@ fn callable_point_sub_works() {
             &[param_region_ptr.into()],
         )
         .unwrap_err();
-    assert!(call_result.to_string().contains("RuntimeError: unreachable"))
+    assert!(call_result
+        .to_string()
+        .contains("RuntimeError: unreachable"))
 }
 
 #[test]
@@ -122,7 +126,9 @@ fn callable_point_mul_works() {
             &[param_region_ptr.into()],
         )
         .unwrap_err();
-    assert!(call_result.to_string().contains("RuntimeError: unreachable"))
+    assert!(call_result
+        .to_string()
+        .contains("RuntimeError: unreachable"))
 }
 
 #[test]
@@ -137,5 +143,7 @@ fn callable_point_number_works() {
     let call_result = instance
         .call_function_strict(&required_exports[0].1, "number", &[])
         .unwrap_err();
-    assert!(call_result.to_string().contains("RuntimeError: unreachable"))
+    assert!(call_result
+        .to_string()
+        .contains("RuntimeError: unreachable"))
 }

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -355,9 +355,9 @@ mod tests {
             mod #module_id {
                 #[link(wasm_import_module = #module_name)]
                 extern "C" {
-                    fn foo(addr: u32, ptr0: u32, ptr1: u32) -> u32;
-                    fn bar(addr: u32);
-                    fn foobar(addr: u32, ptr0: u32, ptr1: u32) -> u32;
+                    pub(crate) fn foo(addr: u32, ptr0: u32, ptr1: u32) -> u32;
+                    pub(crate) fn bar(addr: u32);
+                    pub(crate) fn foobar(addr: u32, ptr0: u32, ptr1: u32) -> u32;
                 }
             }
         };


### PR DESCRIPTION
# Description
This PR renames generated function from `dynamic_link` and `callable_point` macro. This avoids the name conflict with other user-defined functions. See https://github.com/line/cosmwasm/issues/225 for detail.

Closes #225

Caller contracts and callee contracts need to use the same version of macros (before/after this PR).

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (Not Needed)
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
