### PR TITLE
feat: make available user defined mock for dynamic link

### DIFF
--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -51,10 +51,7 @@ pub fn parse_attributes(attr_args: AttributeArgs) -> (Ident, bool) {
             "`dynamic_link` macro needs contract struct id as an unnamed attribute like `#[dynamic_link(CalleeContract)]`"
         )
     };
-    let res_mock = match does_use_mock {
-        Some(does_use) => does_use,
-        None => false,
-    };
+    let res_mock = does_use_mock.unwrap_or(false);
     (res_id, res_mock)
 }
 

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -25,7 +25,7 @@ pub fn parse_attributes(attr_args: AttributeArgs) -> (Ident, bool) {
                 ),
             },
             NestedMeta::Meta(Meta::NameValue(mnv)) => {
-                if ! mnv.path.is_ident("user_defined_mock") {
+                if !mnv.path.is_ident("user_defined_mock") {
                     abort_by_dynamic_link!(
                         nested_meta,
                         "other named attribute than `user_defined_mock` cannot be used in `dynamic_link` macro."

--- a/packages/derive/src/lib.rs
+++ b/packages/derive/src/lib.rs
@@ -136,7 +136,7 @@ pub fn callable_point(_attr: TokenStream, item: TokenStream) -> TokenStream {
 /// #[cfg(not(target_arch = "wasm32"))]
 /// impl TraitName for ContractStruct {
 ///   fn callable_point_on_another_contract(&self, x: i32) -> i32 {
-///     do_something_as_a_mock()
+///     42
 ///   }
 /// }
 /// ```


### PR DESCRIPTION
# Description
This PR enables to make user-defined mock for impl generated by `dynamic_link` macro.

For detail see #227 and added tests in dynamic-caller-contract.

Before 7b1e6dea47b05b1d15fad0bb40de87f572b71d34 is the same as #226 (Review in progress).

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Closes #227

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
