### PR TITLE
feat: limit max regions' length used by calling dynamic link function

### DIFF
--- a/packages/vm/src/errors/communication_error.rs
+++ b/packages/vm/src/errors/communication_error.rs
@@ -32,6 +32,8 @@ pub enum CommunicationError {
     RegionLengthTooBig { length: usize, max_length: usize },
     #[error("Region too small. Got {}, required {}", size, required)]
     RegionTooSmall { size: usize, required: usize },
+    #[error("Regions length too big. limit {}", max_length)]
+    ExceedsLimitLengthCopyRegions { max_length: usize },
     #[error("Got a zero Wasm address")]
     ZeroAddress {},
 }
@@ -62,6 +64,10 @@ impl CommunicationError {
 
     pub(crate) fn region_too_small(size: usize, required: usize) -> Self {
         CommunicationError::RegionTooSmall { size, required }
+    }
+
+    pub(crate) fn exceeds_limit_length_copy_regions(max_length: usize) -> Self {
+        CommunicationError::ExceedsLimitLengthCopyRegions { max_length }
     }
 
     pub(crate) fn zero_address() -> Self {
@@ -126,6 +132,17 @@ mod tests {
             CommunicationError::RegionTooSmall { size, required, .. } => {
                 assert_eq!(size, 12);
                 assert_eq!(required, 33);
+            }
+            e => panic!("Unexpected error: {:?}", e),
+        }
+    }
+
+    #[test]
+    fn exceeds_limit_length_copy_regions_works() {
+        let error = CommunicationError::exceeds_limit_length_copy_regions(42);
+        match error {
+            CommunicationError::ExceedsLimitLengthCopyRegions { max_length, .. } => {
+                assert_eq!(max_length, 42);
             }
             e => panic!("Unexpected error: {:?}", e),
         }


### PR DESCRIPTION
# Description

This PR limits the max length of used by arg/return value's region with the dynamic link.

closes #190

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
