### PR TITLE
feat: force the dynamic linked functions' module name to start with "dynamiclinked_"

### DIFF
--- a/contracts/call-number/tests/integration.rs
+++ b/contracts/call-number/tests/integration.rs
@@ -6,25 +6,26 @@ static CONTRACT_CALLER: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/call_number.wasm");
 
 fn required_imports() -> Vec<(String, String, FunctionType)> {
+    let module_name = "dynamiclinked_NumberContract";
     vec![
         (
             String::from("add"),
-            String::from("dynamiclinked_NumberContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("sub"),
-            String::from("dynamiclinked_NumberContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("mul"),
-            String::from("dynamiclinked_NumberContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("number"),
-            String::from("dynamiclinked_NumberContract"),
+            module_name.to_string(),
             ([Type::I32], [Type::I32]).into(),
         ),
     ]

--- a/contracts/call-number/tests/integration.rs
+++ b/contracts/call-number/tests/integration.rs
@@ -9,22 +9,22 @@ fn required_imports() -> Vec<(String, String, FunctionType)> {
     vec![
         (
             String::from("add"),
-            String::from("NumberContract"),
+            String::from("dynamiclinked_NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("sub"),
-            String::from("NumberContract"),
+            String::from("dynamiclinked_NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("mul"),
-            String::from("NumberContract"),
+            String::from("dynamiclinked_NumberContract"),
             ([Type::I32, Type::I32], []).into(),
         ),
         (
             String::from("number"),
-            String::from("NumberContract"),
+            String::from("dynamiclinked_NumberContract"),
             ([Type::I32], [Type::I32]).into(),
         ),
     ]

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -9,32 +9,32 @@ fn required_imports() -> Vec<(String, String, FunctionType)> {
     vec![
         (
             String::from("pong"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_struct"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_tuple"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_tuple_takes_2_args"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32, Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_env"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("do_panic"),
-            String::from("CalleeContract"),
+            String::from("dynamiclinked_CalleeContract"),
             ([Type::I32], []).into(),
         ),
     ]

--- a/contracts/dynamic-caller-contract/tests/integration.rs
+++ b/contracts/dynamic-caller-contract/tests/integration.rs
@@ -6,35 +6,36 @@ static CONTRACT_CALLER: &[u8] =
     include_bytes!("../target/wasm32-unknown-unknown/release/dynamic_caller_contract.wasm");
 
 fn required_imports() -> Vec<(String, String, FunctionType)> {
+    let module_name = String::from("dynamiclinked_CalleeContract");
     vec![
         (
             String::from("pong"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_struct"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_tuple"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_with_tuple_takes_2_args"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32, Type::I32, Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("pong_env"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32], [Type::I32]).into(),
         ),
         (
             String::from("do_panic"),
-            String::from("dynamiclinked_CalleeContract"),
+            module_name.to_string(),
             ([Type::I32], []).into(),
         ),
     ]

--- a/packages/derive/src/dynamic_link.rs
+++ b/packages/derive/src/dynamic_link.rs
@@ -79,7 +79,7 @@ pub fn generate_import_contract_declaration(
         }
     }
 
-    let module_name = &contract_struct_id.to_string();
+    let module_name = &format!("dynamiclinked_{}", &contract_struct_id.to_string());
     let extern_block = generate_extern_block(module_name, &signatures);
     let implement_block = generate_implements(
         module_name,

--- a/packages/vm/src/compatibility.rs
+++ b/packages/vm/src/compatibility.rs
@@ -115,7 +115,7 @@ fn check_wasm_imports(module: &Module, supported_imports: &[&str]) -> VmResult<(
         let full_name = full_import_name(&required_import);
         if !supported_imports.contains(&full_name.as_str()) {
             let split_name: Vec<&str> = full_name.split('.').collect();
-            if split_name.len() != 2 || split_name[0] == "env" {
+            if split_name.len() != 2 || !split_name[0].starts_with("dynamiclinked_") {
                 return Err(VmError::static_validation_err(format!(
                     "Wasm contract requires unsupported import: \"{}\". Required imports: {}. Available imports: {:?}.",
                     full_name, required_import_names.to_string_limited(200), supported_imports

--- a/packages/vm/src/dynamic_link.rs
+++ b/packages/vm/src/dynamic_link.rs
@@ -140,7 +140,7 @@ pub fn dynamic_link<A: BackendApi, S: Storage, Q: Querier>(
     for ((module_name, func_name, _), import_index) in module_info
         .imports
         .iter()
-        .filter(|((module_name, _, _), _)| module_name != "env")
+        .filter(|((module_name, _, _), _)| module_name.starts_with("dynamiclinked_"))
     {
         if let ImportIndex::Function(func_index) = import_index {
             let func_sig = module_info.signatures[module_info.functions[*func_index]].clone();


### PR DESCRIPTION
# Description
Before this PR, importing modules like WASI API cannot be detected in the dynamic_link branch. This is because all importing is treated as dynamic link functions' import. We want to detect imports other than dynamic link functions and issue an error.
This PR changes the rule of the dynamic linked function's module name and forces them to start with "dynamiclinked_". 

solves #243 

These tests are done in https://github.com/line/lbm-sdk/pull/760 depending https://github.com/line/wasmvm/pull/78
<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (documents about dynamic link should reflect it, but there are no documents yet.)
- [ ] I have added tests to cover my changes. (It will be done in lbm-sdk)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
