### PR TITLE
fix: revert type of Unknown msg

### DIFF
--- a/packages/vm/src/backend.rs
+++ b/packages/vm/src/backend.rs
@@ -188,8 +188,8 @@ pub enum BackendError {
     OutOfGas {},
     #[error("Error in dynamic link: {msg:?}")]
     DynamicLinkErr { msg: String },
-    #[error("Unknown error during call into backend: {msg:?}")]
-    Unknown { msg: Option<String> },
+    #[error("Unknown error during call into backend: {msg}")]
+    Unknown { msg: String },
     // This is the only error case of BackendError that is reported back to the contract.
     #[error("User error during call into backend: {msg}")]
     UserErr { msg: String },
@@ -218,10 +218,8 @@ impl BackendError {
         }
     }
 
-    pub fn unknown<S: ToString>(msg: S) -> Self {
-        BackendError::Unknown {
-            msg: Some(msg.to_string()),
-        }
+    pub fn unknown(msg: impl Into<String>) -> Self {
+        BackendError::Unknown { msg: msg.into() }
     }
 
     pub fn user_err(msg: impl Into<String>) -> Self {
@@ -365,7 +363,7 @@ mod tests {
     fn backend_err_unknown() {
         let error = BackendError::unknown("broken");
         match error {
-            BackendError::Unknown { msg, .. } => assert_eq!(msg.unwrap(), "broken"),
+            BackendError::Unknown { msg, .. } => assert_eq!(msg, "broken"),
             e => panic!("Unexpected error: {:?}", e),
         }
     }

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -423,7 +423,7 @@ mod tests {
             VmError::BackendErr {
                 source: BackendError::Unknown { msg },
                 ..
-            } => assert_eq!(msg.unwrap(), "something went wrong"),
+            } => assert_eq!(msg, "something went wrong"),
             e => panic!("Unexpected error: {:?}", e),
         }
     }

--- a/packages/vm/src/imports.rs
+++ b/packages/vm/src/imports.rs
@@ -964,7 +964,7 @@ mod tests {
             VmError::BackendErr {
                 source: BackendError::Unknown { msg, .. },
                 ..
-            } => assert_eq!(msg.unwrap(), "Temporarily unavailable"),
+            } => assert_eq!(msg, "Temporarily unavailable"),
             err => panic!("Incorrect error returned: {:?}", err),
         }
     }
@@ -1055,7 +1055,7 @@ mod tests {
             VmError::BackendErr {
                 source: BackendError::Unknown { msg, .. },
                 ..
-            } => assert_eq!(msg.unwrap(), "Temporarily unavailable"),
+            } => assert_eq!(msg, "Temporarily unavailable"),
             err => panic!("Incorrect error returned: {:?}", err),
         }
     }
@@ -1157,7 +1157,7 @@ mod tests {
             VmError::BackendErr {
                 source: BackendError::Unknown { msg, .. },
                 ..
-            } => assert_eq!(msg.unwrap(), "Temporarily unavailable"),
+            } => assert_eq!(msg, "Temporarily unavailable"),
             err => panic!("Incorrect error returned: {:?}", err),
         };
     }


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

This PR related to https://github.com/line/cosmwasm/pull/244, https://github.com/line/wasmvm/pull/75
Reverted type of msg.
When applied, [test](https://github.com/line/wasmvm/actions/runs/3368121665/jobs/5586303360) will also be modified.

See: https://github.com/line/cosmwasm/commit/f3b919b31d72094e9e309be700e85fd602c5faa6

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
