### PR TITLE
fix: max address_length on interface validation

### DIFF
--- a/packages/vm/src/dynamic_link.rs
+++ b/packages/vm/src/dynamic_link.rs
@@ -249,7 +249,7 @@ where
     S: Storage + 'static,
     Q: Querier + 'static,
 {
-    let contract_addr_raw = read_region(&env.memory(), address, 64)?;
+    let contract_addr_raw = read_region(&env.memory(), address, MAX_ADDRESS_LENGTH)?;
     let contract_addr: Addr = from_slice(&contract_addr_raw)
         .map_err(|_| RuntimeError::new("Invalid contract address to validate interface"))?;
     let expected_interface_binary = read_region(&env.memory(), interface, MAX_REGIONS_LENGTH)?;


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

I fixed `max_address_length` and used `MAX_ADDRESS_LENGTH` on interface validation.
This PR is related to https://github.com/line/lbm-sdk/actions/runs/3618215697/jobs/6097827653.

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [x] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
