### PR TITLE
feat: add a function to generate callee events from dynamic linked callee instance's event manager

### DIFF
--- a/contracts/events/Cargo.toml
+++ b/contracts/events/Cargo.toml
@@ -30,6 +30,7 @@ cosmwasm-storage = { path = "../../packages/storage", features = ["iterator"] }
 schemars = "0.8.1"
 serde = { version = "1.0.125", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.24" }
+wasmer-types = { version = "2.2.1", features = ["enable-serde"] }
 
 [dev-dependencies]
 cosmwasm-schema = { path = "../../packages/schema" }

--- a/contracts/events/src/contract.rs
+++ b/contracts/events/src/contract.rs
@@ -84,6 +84,7 @@ fn handle_attributes(deps: DepsMut, attributes: Vec<Attribute>) -> Result<Respon
     Ok(Response::default())
 }
 
+/// This issues the given event three times in different ways
 fn handle_event_dyn(
     deps: DepsMut,
     address: Addr,
@@ -104,6 +105,7 @@ fn handle_event_dyn(
     Ok(Response::default().add_event(event))
 }
 
+/// This issues given events three times in different ways
 fn handle_events_dyn(
     deps: DepsMut,
     address: Addr,
@@ -121,6 +123,7 @@ fn handle_events_dyn(
     Ok(Response::default().add_events(events))
 }
 
+/// This issues the given attribute three times in different ways
 fn handle_attribute_dyn(
     deps: DepsMut,
     address: Addr,
@@ -139,6 +142,7 @@ fn handle_attribute_dyn(
     Ok(Response::default().add_attribute(key, value))
 }
 
+/// This issues the given attributes three times in different ways
 fn handle_attributes_dyn(
     deps: DepsMut,
     address: Addr,

--- a/contracts/events/src/contract.rs
+++ b/contracts/events/src/contract.rs
@@ -1,7 +1,23 @@
-use cosmwasm_std::{entry_point, Attribute, DepsMut, Env, Event, MessageInfo, Response};
+use cosmwasm_std::{
+    callable_point, dynamic_link, entry_point, Addr, Attribute, Contract, DepsMut, Env, Event,
+    MessageInfo, Response,
+};
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg};
+
+#[derive(Contract)]
+struct EventsContract {
+    address: Addr,
+}
+
+#[dynamic_link(EventsContract)]
+trait Events: Contract {
+    fn add_event_dyn(&self, ty: String, attributes: Vec<Attribute>);
+    fn add_events_dyn(&self, events: Vec<Event>);
+    fn add_attribute_dyn(&self, key: String, value: String);
+    fn add_attributes_dyn(&self, attributes: Vec<Attribute>);
+}
 
 #[entry_point]
 pub fn instantiate(
@@ -25,6 +41,21 @@ pub fn execute(
         ExecuteMsg::Events { events } => handle_events(deps, events),
         ExecuteMsg::Attribute { key, value } => handle_attribute(deps, key, value),
         ExecuteMsg::Attributes { attributes } => handle_attributes(deps, attributes),
+        ExecuteMsg::EventDyn {
+            address,
+            ty,
+            attributes,
+        } => handle_event_dyn(deps, address, ty, attributes),
+        ExecuteMsg::EventsDyn { address, events } => handle_events_dyn(deps, address, events),
+        ExecuteMsg::AttributeDyn {
+            address,
+            key,
+            value,
+        } => handle_attribute_dyn(deps, address, key, value),
+        ExecuteMsg::AttributesDyn {
+            address,
+            attributes,
+        } => handle_attributes_dyn(deps, address, attributes),
     }
 }
 
@@ -51,4 +82,97 @@ fn handle_attribute(deps: DepsMut, key: String, value: String) -> Result<Respons
 fn handle_attributes(deps: DepsMut, attributes: Vec<Attribute>) -> Result<Response, ContractError> {
     deps.api.add_attributes(&attributes)?;
     Ok(Response::default())
+}
+
+fn handle_event_dyn(
+    deps: DepsMut,
+    address: Addr,
+    ty: String,
+    attributes: Vec<Attribute>,
+) -> Result<Response, ContractError> {
+    let contract = EventsContract { address };
+
+    // issue event via dynamic link
+    contract.add_event_dyn(ty.clone(), attributes.clone());
+
+    let event = Event::new(ty).add_attributes(attributes);
+
+    // issue event via api
+    deps.api.add_event(&event)?;
+
+    // issue event via response
+    Ok(Response::default().add_event(event))
+}
+
+fn handle_events_dyn(
+    deps: DepsMut,
+    address: Addr,
+    events: Vec<Event>,
+) -> Result<Response, ContractError> {
+    let contract = EventsContract { address };
+
+    // issue events via dynamic link
+    contract.add_events_dyn(events.clone());
+
+    // issue events via api
+    deps.api.add_events(&events)?;
+
+    // issue events via response
+    Ok(Response::default().add_events(events))
+}
+
+fn handle_attribute_dyn(
+    deps: DepsMut,
+    address: Addr,
+    key: String,
+    value: String,
+) -> Result<Response, ContractError> {
+    let contract = EventsContract { address };
+
+    // issue attribute via dynamic link
+    contract.add_attribute_dyn(key.clone(), value.clone());
+
+    // issue attribute via api
+    deps.api.add_attribute(&key, &value)?;
+
+    // issue attribute via response
+    Ok(Response::default().add_attribute(key, value))
+}
+
+fn handle_attributes_dyn(
+    deps: DepsMut,
+    address: Addr,
+    attributes: Vec<Attribute>,
+) -> Result<Response, ContractError> {
+    let contract = EventsContract { address };
+
+    // issue attributes via dynamic link
+    contract.add_attributes_dyn(attributes.clone());
+
+    // issue attributes via api
+    deps.api.add_attributes(&attributes)?;
+
+    // issue attributes via response
+    Ok(Response::default().add_attributes(attributes))
+}
+
+#[callable_point]
+fn add_event_dyn(deps: DepsMut, _env: Env, ty: String, attributes: Vec<Attribute>) {
+    let event = Event::new(ty).add_attributes(attributes);
+    deps.api.add_event(&event).unwrap();
+}
+
+#[callable_point]
+fn add_events_dyn(deps: DepsMut, _env: Env, events: Vec<Event>) {
+    deps.api.add_events(&events).unwrap();
+}
+
+#[callable_point]
+fn add_attribute_dyn(deps: DepsMut, _env: Env, key: String, value: String) {
+    deps.api.add_attribute(&key, &value).unwrap();
+}
+
+#[callable_point]
+fn add_attributes_dyn(deps: DepsMut, _env: Env, attributes: Vec<Attribute>) {
+    deps.api.add_attributes(&attributes).unwrap();
 }

--- a/contracts/events/src/msg.rs
+++ b/contracts/events/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Attribute, Event};
+use cosmwasm_std::{Addr, Attribute, Event};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +21,25 @@ pub enum ExecuteMsg {
         value: String,
     },
     Attributes {
+        attributes: Vec<Attribute>,
+    },
+    EventDyn {
+        address: Addr,
+        #[serde(rename = "type")]
+        ty: String,
+        attributes: Vec<Attribute>,
+    },
+    EventsDyn {
+        address: Addr,
+        events: Vec<Event>,
+    },
+    AttributeDyn {
+        address: Addr,
+        key: String,
+        value: String,
+    },
+    AttributesDyn {
+        address: Addr,
         attributes: Vec<Attribute>,
     },
 }

--- a/packages/vm/src/environment.rs
+++ b/packages/vm/src/environment.rs
@@ -480,7 +480,7 @@ impl<A: BackendApi, S: Storage, Q: Querier> Environment<A, S, Q> {
             Ok((env, ctx.dynamic_callstack.clone()))
         });
         let (env, mut callstack) = res?;
-        if callstack.len() < 1 {
+        if callstack.is_empty() {
             return Err(VmError::invalid_context("generate_events_as_from_dynamic_linked_callee is called with non-callee environment."));
         };
 

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -400,7 +400,7 @@ impl From<wasmer::RuntimeError> for VmError {
             original.to_string().starts_with(&message),
             "The error message we created is not a prefix of the error message from Wasmer. Our message: '{}'. Wasmer messsage: '{}'",
             &message,
-            original.to_string()
+            original
         );
         VmError::runtime_err(format!("Wasmer runtime error: {}", &message))
     }

--- a/packages/vm/src/errors/vm_error.rs
+++ b/packages/vm/src/errors/vm_error.rs
@@ -156,6 +156,12 @@ pub enum VmError {
         #[cfg(feature = "backtraces")]
         backtrace: Backtrace,
     },
+    #[error("Some function is called in invalid context: {}", msg)]
+    InvalidContext {
+        msg: String,
+        #[cfg(feature = "backtraces")]
+        backtrace: Backtrace,
+    },
 }
 
 impl VmError {
@@ -332,8 +338,17 @@ impl VmError {
             backtrace: Backtrace::capture(),
         }
     }
+
     pub(crate) fn dynamic_call_depth_over_limitation_err() -> Self {
         VmError::DynamicCallDepthOverLimitationErr {
+            #[cfg(feature = "backtraces")]
+            backtrace: Backtrace::capture(),
+        }
+    }
+
+    pub(crate) fn invalid_context(msg: impl Into<String>) -> Self {
+        VmError::InvalidContext {
+            msg: msg.into(),
             #[cfg(feature = "backtraces")]
             backtrace: Backtrace::capture(),
         }

--- a/packages/vm/src/instance.rs
+++ b/packages/vm/src/instance.rs
@@ -431,6 +431,11 @@ where
     pub fn get_events_attributes(&self) -> (Vec<Event>, Vec<Attribute>) {
         self.env.get_events_attributes()
     }
+
+    /// Generate events from `context_data.EventManager` as from dynamic linked callee instance.
+    pub fn generate_events_as_from_dynamic_linked_callee(&self) -> VmResult<Vec<Event>> {
+        self.env.generate_events_as_from_dynamic_linked_callee()
+    }
 }
 
 /// This exists only to be exported through `internals` for use by crates that are


### PR DESCRIPTION
# Description
A part of the 3rd part of https://github.com/line/cosmwasm/issues/265.

This PR adds a function to generate callee events from a dynamic linked callee instance's event manager. This function is for copy callee's event manager info to caller's event manager.

And, this PR also improve the events contract to useable as a dynamic linked contract. This contract is used by tests implemented in wasmvm's PR.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/cosmwasm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
